### PR TITLE
Add public API v1 with token auth, board access, and AI datasource injection

### DIFF
--- a/docs/api-v1-spec.md
+++ b/docs/api-v1-spec.md
@@ -1,0 +1,583 @@
+# Teambeat Public API v1 — Specification
+
+Version: 1.0  
+Base path: `/api/v1`  
+Content-Type: `application/json`
+
+---
+
+## Authentication
+
+Every v1 endpoint accepts one of two credential types:
+
+### Bearer Token (primary — for AI/programmatic clients)
+
+```
+Authorization: Bearer tb_<64-hex-chars>
+```
+
+Tokens are created on the profile page. A token is a cryptographically random 256-bit value
+prefixed with `tb_`. The server stores only its SHA-256 hash; the raw token is shown **once**
+at creation and cannot be retrieved again.
+
+Default token lifetime: **90 days** from creation.
+
+### Session Cookie (secondary — browser clients)
+
+The existing `session` cookie is also accepted on all v1 routes, so the browser UI can call
+the same endpoints without needing a token.
+
+### Error response when unauthenticated
+
+```json
+HTTP 401
+{ "success": false, "error": "Unauthorized" }
+```
+
+---
+
+## Token Management
+
+### `GET /api/v1/tokens`
+
+List all active API tokens for the authenticated user. Token hashes are **never** returned.
+
+**Response 200**
+```json
+{
+  "success": true,
+  "tokens": [
+    {
+      "id": "uuid",
+      "label": "My AI integration",
+      "expiresAt": 1780000000000,
+      "lastUsedAt": 1770000000000,
+      "createdAt": 1750000000000
+    }
+  ]
+}
+```
+
+---
+
+### `POST /api/v1/tokens`
+
+Create a new API token. The `token` field in the response is the **only time** the raw token
+is available.
+
+**Request body**
+```json
+{ "label": "My AI integration" }
+```
+
+| Field   | Type   | Required | Constraints          |
+|---------|--------|----------|----------------------|
+| `label` | string | yes      | 1–100 characters     |
+
+**Response 201**
+```json
+{
+  "success": true,
+  "token": "tb_a3f2b1c4...",
+  "tokenInfo": {
+    "id": "uuid",
+    "label": "My AI integration",
+    "expiresAt": 1780000000000,
+    "createdAt": 1750000000000
+  }
+}
+```
+
+**Errors**
+
+| Status | Error                        | Cause                          |
+|--------|------------------------------|--------------------------------|
+| 400    | `"label is required"`        | Missing or empty label         |
+| 400    | `"Invalid input"`            | Label >100 chars               |
+
+---
+
+### `DELETE /api/v1/tokens/:id`
+
+Revoke a token immediately. Only the token owner can revoke it.
+
+**Response 200**
+```json
+{ "success": true }
+```
+
+**Errors**
+
+| Status | Error              | Cause                                   |
+|--------|--------------------|-----------------------------------------|
+| 404    | `"Token not found"` | ID doesn't exist or belongs to another user |
+
+---
+
+## Series
+
+### `GET /api/v1/series`
+
+List all series the authenticated user is a member of.
+
+**Response 200**
+```json
+{
+  "success": true,
+  "series": [
+    {
+      "id": "uuid",
+      "name": "Engineering Retrospectives",
+      "slug": "eng-retros",
+      "description": "Bi-weekly retros for the eng team",
+      "role": "admin",
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    }
+  ]
+}
+```
+
+---
+
+### `GET /api/v1/series/:id/boards`
+
+List boards in a series. Returns boards ordered by `meetingDate` descending (most recent first),
+falling back to `createdAt`.
+
+**Query parameters**
+
+| Param    | Type   | Default | Description                                       |
+|----------|--------|---------|---------------------------------------------------|
+| `status` | string | all     | Filter by status: `draft`, `active`, `completed`, `archived` |
+| `limit`  | number | 20      | Max results (1–100)                               |
+| `offset` | number | 0       | Pagination offset                                 |
+
+**Response 200**
+```json
+{
+  "success": true,
+  "boards": [
+    {
+      "id": "uuid",
+      "name": "Sprint 42 Retro",
+      "status": "completed",
+      "meetingDate": "2026-06-01",
+      "createdAt": "2026-05-30T10:00:00.000Z",
+      "sceneCount": 4,
+      "cardCount": 27,
+      "agreementCount": 5
+    }
+  ],
+  "meta": { "total": 42, "limit": 20, "offset": 0 }
+}
+```
+
+**Errors**
+
+| Status | Error               | Cause                              |
+|--------|---------------------|------------------------------------|
+| 403    | `"Access denied"`   | User is not a member of the series |
+| 404    | `"Series not found"`| Series ID does not exist           |
+
+---
+
+### `POST /api/v1/series/:id/boards`
+
+Create a new board in the series with an optional full structure (scenes, columns, seed cards).
+All sub-resources are created atomically; if any fail the whole operation rolls back.
+
+**Request body**
+```json
+{
+  "name": "Sprint 43 Retro",
+  "meetingDate": "2026-06-15",
+  "blameFreeMode": false,
+  "votingAllocation": 3,
+  "columns": [
+    { "title": "What went well",    "seq": 1 },
+    { "title": "What needs work",   "seq": 2 },
+    { "title": "Shout-outs",        "seq": 3 }
+  ],
+  "scenes": [
+    { "title": "Collect",  "mode": "columns",    "seq": 1, "flags": ["allow_add_cards", "allow_edit_cards"] },
+    { "title": "Vote",     "mode": "columns",    "seq": 2, "flags": ["allow_voting", "show_votes"] },
+    { "title": "Discuss",  "mode": "review",     "seq": 3 },
+    { "title": "Actions",  "mode": "agreements", "seq": 4 }
+  ],
+  "cards": [
+    { "columnTitle": "What went well", "content": "Deployed on time" },
+    { "columnTitle": "What needs work", "content": "Test coverage gaps" }
+  ]
+}
+```
+
+| Field              | Type    | Required | Constraints                               |
+|--------------------|---------|----------|-------------------------------------------|
+| `name`             | string  | yes      | 1–100 chars                               |
+| `meetingDate`      | string  | no       | ISO date `YYYY-MM-DD`                     |
+| `blameFreeMode`    | boolean | no       | Default `false`                           |
+| `votingAllocation` | number  | no       | Integer 0–10, default 3                   |
+| `columns`          | array   | no       | Up to 20 columns                          |
+| `columns[].title`  | string  | yes      | 1–100 chars                               |
+| `columns[].seq`    | number  | no       | Auto-assigned if omitted                  |
+| `scenes`           | array   | no       | Up to 20 scenes                           |
+| `scenes[].title`   | string  | yes      | 1–100 chars                               |
+| `scenes[].mode`    | string  | yes      | `columns`, `present`, `review`, `agreements`, `scorecard`, `static`, `survey`, `quadrant` |
+| `scenes[].seq`     | number  | no       | Auto-assigned if omitted                  |
+| `scenes[].flags`   | array   | no       | Scene capability flags                    |
+| `cards`            | array   | no       | Seed cards; require at least one column   |
+| `cards[].columnTitle` | string | yes   | Must match a column title in this request |
+| `cards[].content`  | string  | yes      | 1–2000 chars                              |
+
+**Scene flags** (any subset):
+`allow_add_cards`, `allow_edit_cards`, `allow_obscure_cards`, `allow_move_cards`,
+`allow_group_cards`, `show_votes`, `allow_voting`, `show_comments`, `allow_comments`,
+`multiple_votes_per_card`
+
+**Response 201**
+```json
+{
+  "success": true,
+  "board": {
+    "id": "uuid",
+    "name": "Sprint 43 Retro",
+    "status": "draft",
+    "meetingDate": "2026-06-15",
+    "columns": [ { "id": "uuid", "title": "What went well", "seq": 1 } ],
+    "scenes": [ { "id": "uuid", "title": "Collect", "mode": "columns", "seq": 1, "flags": ["allow_add_cards"] } ],
+    "cards": [ { "id": "uuid", "columnId": "uuid", "content": "Deployed on time" } ],
+    "createdAt": "2026-06-10T00:00:00.000Z"
+  }
+}
+```
+
+**Errors**
+
+| Status | Error                                     | Cause                                |
+|--------|-------------------------------------------|--------------------------------------|
+| 400    | `"Invalid input"`                         | Zod validation failure               |
+| 400    | `"Card references unknown column: '...'"` | columnTitle doesn't match any column |
+| 403    | `"Access denied"`                         | User not a series member             |
+| 404    | `"Series not found"`                      | Series ID does not exist             |
+
+---
+
+### `GET /api/v1/series/:id/agreements`
+
+All action items across every board in the series.
+
+**Query parameters**
+
+| Param       | Type    | Default | Description                         |
+|-------------|---------|---------|-------------------------------------|
+| `completed` | boolean | all     | `true` / `false` to filter by state |
+| `limit`     | number  | 50      | Max results (1–200)                 |
+| `offset`    | number  | 0       | Pagination offset                   |
+
+**Response 200**
+```json
+{
+  "success": true,
+  "agreements": [
+    {
+      "id": "uuid",
+      "content": "Add integration tests for auth flow",
+      "completed": false,
+      "boardId": "uuid",
+      "boardName": "Sprint 42 Retro",
+      "meetingDate": "2026-06-01",
+      "createdAt": "2026-06-01T15:30:00.000Z",
+      "completedAt": null,
+      "completedByName": null
+    }
+  ],
+  "meta": { "total": 12, "limit": 50, "offset": 0 }
+}
+```
+
+---
+
+### `GET /api/v1/series/:id/health-summary`
+
+Time-series view of survey (health check) responses across all boards in the series.
+Questions are grouped by `threadId` so longitudinal tracking is possible even across boards.
+
+**Query parameters**
+
+| Param      | Type   | Default | Description                               |
+|------------|--------|---------|-------------------------------------------|
+| `limit`    | number | 10      | Number of most-recent boards to include   |
+
+**Response 200**
+```json
+{
+  "success": true,
+  "series": { "id": "uuid", "name": "Engineering Retrospectives" },
+  "questions": [
+    {
+      "threadId": "some-thread-id",
+      "question": "How is team morale?",
+      "questionType": "range1to5",
+      "history": [
+        {
+          "boardId": "uuid",
+          "boardName": "Sprint 42 Retro",
+          "meetingDate": "2026-06-01",
+          "avgRating": 3.8,
+          "responseCount": 6,
+          "distribution": { "1": 0, "2": 1, "3": 1, "4": 3, "5": 1 }
+        }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+## Boards
+
+### `GET /api/v1/boards/:id`
+
+Full board detail including all scenes, columns, cards (with vote counts), and comments.
+
+**Response 200**
+```json
+{
+  "success": true,
+  "board": {
+    "id": "uuid",
+    "seriesId": "uuid",
+    "name": "Sprint 42 Retro",
+    "status": "completed",
+    "meetingDate": "2026-06-01",
+    "blameFreeMode": false,
+    "votingAllocation": 3,
+    "currentSceneId": "uuid",
+    "columns": [
+      { "id": "uuid", "title": "What went well", "seq": 1 }
+    ],
+    "scenes": [
+      {
+        "id": "uuid",
+        "title": "Collect",
+        "mode": "columns",
+        "seq": 1,
+        "flags": ["allow_add_cards", "allow_edit_cards"]
+      }
+    ],
+    "cards": [
+      {
+        "id": "uuid",
+        "columnId": "uuid",
+        "content": "Deployed on time",
+        "voteCount": 4,
+        "commentCount": 2,
+        "groupId": null,
+        "createdAt": "2026-06-01T10:00:00.000Z"
+      }
+    ],
+    "createdAt": "2026-05-30T10:00:00.000Z"
+  }
+}
+```
+
+**Errors**
+
+| Status | Error               | Cause                                |
+|--------|---------------------|--------------------------------------|
+| 403    | `"Access denied"`   | User not a member of the board's series |
+| 404    | `"Board not found"` | Board ID does not exist              |
+
+---
+
+### `GET /api/v1/boards/:id/cards`
+
+All cards in a board with vote counts, comment counts, and group info.
+
+**Response 200**
+```json
+{
+  "success": true,
+  "cards": [
+    {
+      "id": "uuid",
+      "columnId": "uuid",
+      "columnTitle": "What went well",
+      "content": "Deployed on time",
+      "notes": null,
+      "voteCount": 4,
+      "commentCount": 2,
+      "groupId": null,
+      "isGroupLead": false,
+      "seq": 1,
+      "createdAt": "2026-06-01T10:00:00.000Z"
+    }
+  ]
+}
+```
+
+---
+
+### `GET /api/v1/boards/:id/agreements`
+
+Action items for a single board.
+
+**Query parameters**
+
+| Param       | Type    | Default | Description                         |
+|-------------|---------|---------|-------------------------------------|
+| `completed` | boolean | all     | Filter by completion state          |
+
+**Response 200**
+```json
+{
+  "success": true,
+  "agreements": [
+    {
+      "id": "uuid",
+      "content": "Add integration tests",
+      "completed": false,
+      "createdAt": "2026-06-01T15:30:00.000Z",
+      "completedAt": null,
+      "completedByName": null
+    }
+  ]
+}
+```
+
+---
+
+### `GET /api/v1/boards/:id/scorecard-results`
+
+All processed scorecard results attached to scenes in this board.
+
+**Response 200**
+```json
+{
+  "success": true,
+  "results": [
+    {
+      "sceneScorecardId": "uuid",
+      "sceneId": "uuid",
+      "sceneTitle": "Data Review",
+      "scorecardName": "Sprint Metrics",
+      "datasourceName": "Velocity",
+      "section": "Delivery",
+      "title": "Velocity trending down 3 sprints",
+      "primaryValue": "-18%",
+      "secondaryValues": { "current": "35", "previous": "43" },
+      "severity": "warning",
+      "seq": 1
+    }
+  ]
+}
+```
+
+---
+
+## AI Datasource Injection
+
+### `POST /api/v1/datasources/:id/inject`
+
+Push pre-processed scorecard results into a datasource. Intended for AI clients that analyze
+data externally and push findings for display in the next board meeting. Requires the
+datasource's `sourceType` to be `"ai"`.
+
+The authenticated user must be a member of the series that owns the scorecard containing
+this datasource.
+
+**Request body**
+```json
+{
+  "data": [
+    {
+      "section": "Delivery",
+      "title": "Velocity trending down 3 sprints",
+      "primaryValue": "-18%",
+      "secondaryValues": { "current": "35", "previous": "43", "baseline": "43" },
+      "severity": "warning",
+      "sourceData": { "sprint_42": 35, "sprint_41": 38, "sprint_40": 43 }
+    }
+  ]
+}
+```
+
+| Field                  | Type   | Required | Constraints                           |
+|------------------------|--------|----------|---------------------------------------|
+| `data`                 | array  | yes      | 1–500 items                           |
+| `data[].section`       | string | yes      | 1–100 chars; groups results visually  |
+| `data[].title`         | string | yes      | 1–200 chars                           |
+| `data[].primaryValue`  | string | no       | Display value (e.g., `"-18%"`)        |
+| `data[].secondaryValues` | object | no    | Key/value pairs for detail display    |
+| `data[].severity`      | string | no       | `info` (default), `warning`, `critical` |
+| `data[].sourceData`    | any    | no       | Raw evidence attached to the result   |
+
+The server stores these as the datasource's pending injection. On the next scorecard
+collection (when a facilitator runs a scene containing this scorecard), the injected data
+replaces any prior injection for this datasource.
+
+**Response 200**
+```json
+{
+  "success": true,
+  "injected": 3
+}
+```
+
+**Errors**
+
+| Status | Error                              | Cause                                         |
+|--------|------------------------------------|-----------------------------------------------|
+| 400    | `"Invalid input"`                  | Validation failure                            |
+| 403    | `"Access denied"`                  | User not in series, or datasource not 'ai' type |
+| 404    | `"Datasource not found"`           | Datasource ID does not exist                  |
+
+---
+
+## OpenAPI Schema
+
+### `GET /api/v1/openapi.json`
+
+Returns the full OpenAPI 3.1 specification for all v1 endpoints. Unauthenticated.
+Intended for AI tooling (GPT plugins, Claude tools, Copilot Workspace) to discover and
+call the API without additional documentation.
+
+---
+
+## Common Error Shape
+
+All error responses follow:
+
+```json
+{
+  "success": false,
+  "error": "Human-readable message",
+  "details": [ ... ]
+}
+```
+
+`details` is present only for Zod validation errors and contains the raw Zod issue array.
+
+---
+
+## Rate Limits
+
+Token-authenticated requests share the same per-IP rate limits as session-authenticated ones:
+- Board/card creation: 30 per minute
+- Auth operations: not applicable (tokens bypass auth rate limiting)
+
+---
+
+## Migration Safety Notes
+
+The `api_tokens` table is introduced in migration `0016_add_api_tokens`. Both PostgreSQL and
+SQLite migrations are handwritten to avoid the known Drizzle composite-index auto-generation
+bug. Only single-column indexes are used on this table:
+- `api_tokens_token_hash_unique` — unique index on `token_hash`
+- `api_tokens_user_id_idx` — index on `user_id`
+
+The postgres migration journal was missing entry 15 (`0015_add_continuation_fields`) which
+has been corrected. The file existed but was not registered; it is idempotent and safe to
+apply to databases that already have those columns (uses `IF NOT EXISTS` / `IF NOT EXISTS`
+pattern with a DO-block guard in postgres).

--- a/drizzle/postgres/0015_add_continuation_fields.sql
+++ b/drizzle/postgres/0015_add_continuation_fields.sql
@@ -1,2 +1,20 @@
-ALTER TABLE "scenes" ADD COLUMN "continuation_enabled" boolean DEFAULT false NOT NULL;--> statement-breakpoint
-ALTER TABLE "scenes" ADD COLUMN "continuation_scene_id" text;
+-- Add continuation fields to scenes (survey multi-phase support)
+-- Idempotent: safe to run on databases that already have these columns.
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'scenes' AND column_name = 'continuation_enabled'
+  ) THEN
+    ALTER TABLE "scenes" ADD COLUMN "continuation_enabled" boolean DEFAULT false NOT NULL;
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'scenes' AND column_name = 'continuation_scene_id'
+  ) THEN
+    ALTER TABLE "scenes" ADD COLUMN "continuation_scene_id" text;
+  END IF;
+END $$;

--- a/drizzle/postgres/0016_add_api_tokens.sql
+++ b/drizzle/postgres/0016_add_api_tokens.sql
@@ -1,0 +1,18 @@
+-- Add api_tokens table for programmatic / AI access
+-- Handwritten migration: do NOT regenerate with drizzle-kit (composite index bug)
+-- Token hashes are SHA-256 of the raw tb_* token; raw tokens are never stored.
+
+CREATE TABLE IF NOT EXISTS "api_tokens" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"token_hash" text NOT NULL,
+	"label" text NOT NULL,
+	"expires_at" bigint NOT NULL,
+	"last_used_at" bigint,
+	"created_at" bigint NOT NULL,
+	CONSTRAINT "api_tokens_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "api_tokens_token_hash_unique" ON "api_tokens" ("token_hash");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "api_tokens_user_id_idx" ON "api_tokens" ("user_id");

--- a/drizzle/postgres/meta/_journal.json
+++ b/drizzle/postgres/meta/_journal.json
@@ -106,6 +106,20 @@
       "when": 1762000000000,
       "tag": "0014_add_feature_analytics_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1768674525795,
+      "tag": "0015_add_continuation_fields",
+      "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1769000000000,
+      "tag": "0016_add_api_tokens",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/sqlite/0016_add_api_tokens.sql
+++ b/drizzle/sqlite/0016_add_api_tokens.sql
@@ -1,0 +1,17 @@
+-- Add api_tokens table for programmatic / AI access
+-- Handwritten migration: do NOT regenerate with drizzle-kit (composite index bug)
+-- Token hashes are SHA-256 of the raw tb_* token; raw tokens are never stored.
+
+CREATE TABLE IF NOT EXISTS `api_tokens` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL REFERENCES `users`(`id`) ON DELETE CASCADE,
+	`token_hash` text NOT NULL,
+	`label` text NOT NULL,
+	`expires_at` integer NOT NULL,
+	`last_used_at` integer,
+	`created_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `api_tokens_token_hash_unique` ON `api_tokens` (`token_hash`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `api_tokens_user_id_idx` ON `api_tokens` (`user_id`);

--- a/drizzle/sqlite/meta/_journal.json
+++ b/drizzle/sqlite/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1768674525795,
       "tag": "0015_lovely_bloodaxe",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "6",
+      "when": 1769000000000,
+      "tag": "0016_add_api_tokens",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/components/ApiTokenManager.svelte
+++ b/src/lib/components/ApiTokenManager.svelte
@@ -1,0 +1,326 @@
+<script lang="ts">
+import { onMount } from "svelte";
+
+interface TokenInfo {
+	id: string;
+	label: string;
+	expiresAt: number;
+	lastUsedAt: number | null;
+	createdAt: number;
+}
+
+let tokens: TokenInfo[] = $state([]);
+let loading = $state(true);
+let newLabel = $state("");
+let creating = $state(false);
+let newToken = $state<string | null>(null);
+let error = $state("");
+let copied = $state(false);
+
+onMount(loadTokens);
+
+async function loadTokens() {
+	loading = true;
+	try {
+		const res = await fetch("/api/v1/tokens");
+		if (res.ok) {
+			const data = await res.json();
+			tokens = data.tokens ?? [];
+		}
+	} catch {
+		error = "Failed to load tokens";
+	} finally {
+		loading = false;
+	}
+}
+
+async function createToken() {
+	if (!newLabel.trim()) return;
+	creating = true;
+	error = "";
+	newToken = null;
+
+	try {
+		const res = await fetch("/api/v1/tokens", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ label: newLabel.trim() }),
+		});
+		const data = await res.json();
+
+		if (res.ok && data.success) {
+			newToken = data.token;
+			tokens = [data.tokenInfo, ...tokens];
+			newLabel = "";
+		} else {
+			error = data.error ?? "Failed to create token";
+		}
+	} catch {
+		error = "Failed to create token";
+	} finally {
+		creating = false;
+	}
+}
+
+async function revokeToken(id: string) {
+	try {
+		const res = await fetch(`/api/v1/tokens/${id}`, { method: "DELETE" });
+		if (res.ok) {
+			tokens = tokens.filter((t) => t.id !== id);
+			if (newToken) newToken = null;
+		} else {
+			const data = await res.json();
+			error = data.error ?? "Failed to revoke token";
+		}
+	} catch {
+		error = "Failed to revoke token";
+	}
+}
+
+async function copyToken() {
+	if (!newToken) return;
+	try {
+		await navigator.clipboard.writeText(newToken);
+		copied = true;
+		setTimeout(() => (copied = false), 2000);
+	} catch {
+		// clipboard not available
+	}
+}
+
+function formatDate(ms: number) {
+	return new Date(ms).toLocaleDateString(undefined, {
+		year: "numeric",
+		month: "short",
+		day: "numeric",
+	});
+}
+
+function isExpiringSoon(expiresAt: number) {
+	const days = (expiresAt - Date.now()) / (1000 * 60 * 60 * 24);
+	return days < 14;
+}
+</script>
+
+<div class="token-manager">
+	<h3>API Tokens</h3>
+	<p class="description">
+		Tokens let AI and automation clients access your boards. Each token lasts 90 days. The raw
+		token is shown only once — store it securely.
+	</p>
+
+	{#if error}
+		<p class="error">{error}</p>
+	{/if}
+
+	{#if newToken}
+		<div class="new-token-banner">
+			<p><strong>New token created.</strong> Copy it now — it won't be shown again.</p>
+			<div class="token-display">
+				<code>{newToken}</code>
+				<button class="btn-copy" onclick={copyToken}>
+					{copied ? "Copied!" : "Copy"}
+				</button>
+			</div>
+			<button class="btn-dismiss" onclick={() => (newToken = null)}>Dismiss</button>
+		</div>
+	{/if}
+
+	<form class="create-form" onsubmit={(e) => { e.preventDefault(); createToken(); }}>
+		<input
+			type="text"
+			placeholder="Token label (e.g. My AI agent)"
+			bind:value={newLabel}
+			maxlength="100"
+			disabled={creating}
+		/>
+		<button type="submit" disabled={creating || !newLabel.trim()}>
+			{creating ? "Creating…" : "Create token"}
+		</button>
+	</form>
+
+	{#if loading}
+		<p class="loading">Loading tokens…</p>
+	{:else if tokens.length === 0}
+		<p class="empty">No active tokens. Create one above.</p>
+	{:else}
+		<ul class="token-list">
+			{#each tokens as token (token.id)}
+				<li class="token-item" class:expiring={isExpiringSoon(token.expiresAt)}>
+					<div class="token-info">
+						<span class="token-label">{token.label}</span>
+						<span class="token-meta">
+							Created {formatDate(token.createdAt)} · Expires {formatDate(token.expiresAt)}
+							{#if token.lastUsedAt}
+								· Last used {formatDate(token.lastUsedAt)}
+							{/if}
+						</span>
+						{#if isExpiringSoon(token.expiresAt)}
+							<span class="expiry-warning">Expiring soon</span>
+						{/if}
+					</div>
+					<button
+						class="btn-revoke"
+						onclick={() => revokeToken(token.id)}
+					>
+						Revoke
+					</button>
+				</li>
+			{/each}
+		</ul>
+	{/if}
+
+	<p class="docs-link">
+		<a href="/api/v1/openapi.json" target="_blank" rel="noopener noreferrer">
+			View API documentation (OpenAPI)
+		</a>
+	</p>
+</div>
+
+<style>
+.token-manager {
+	margin-top: 2rem;
+}
+
+h3 {
+	margin-bottom: 0.25rem;
+}
+
+.description {
+	color: var(--color-text-secondary, #666);
+	font-size: 0.9rem;
+	margin-bottom: 1rem;
+}
+
+.error {
+	color: var(--color-danger, #c0392b);
+	margin-bottom: 0.75rem;
+}
+
+.new-token-banner {
+	background: var(--color-success-bg, #eafaf1);
+	border: 1px solid var(--color-success, #27ae60);
+	border-radius: 6px;
+	padding: 1rem;
+	margin-bottom: 1rem;
+}
+
+.token-display {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	margin: 0.5rem 0;
+}
+
+.token-display code {
+	font-size: 0.85rem;
+	background: var(--color-code-bg, #f0f0f0);
+	padding: 0.25rem 0.5rem;
+	border-radius: 4px;
+	word-break: break-all;
+	flex: 1;
+}
+
+.btn-copy {
+	padding: 0.25rem 0.75rem;
+	font-size: 0.85rem;
+	cursor: pointer;
+	white-space: nowrap;
+}
+
+.btn-dismiss {
+	font-size: 0.8rem;
+	background: none;
+	border: none;
+	cursor: pointer;
+	text-decoration: underline;
+	color: var(--color-text-secondary, #666);
+}
+
+.create-form {
+	display: flex;
+	gap: 0.5rem;
+	margin-bottom: 1.5rem;
+}
+
+.create-form input {
+	flex: 1;
+	padding: 0.5rem 0.75rem;
+	border: 1px solid var(--color-border, #ccc);
+	border-radius: 4px;
+	font-size: 0.95rem;
+}
+
+.create-form button {
+	padding: 0.5rem 1rem;
+	cursor: pointer;
+	white-space: nowrap;
+}
+
+.loading,
+.empty {
+	color: var(--color-text-secondary, #666);
+	font-size: 0.9rem;
+}
+
+.token-list {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+}
+
+.token-item {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 0.75rem 0;
+	border-bottom: 1px solid var(--color-border, #eee);
+	gap: 1rem;
+}
+
+.token-item.expiring .token-label {
+	color: var(--color-warning, #e67e22);
+}
+
+.token-info {
+	display: flex;
+	flex-direction: column;
+	gap: 0.15rem;
+}
+
+.token-label {
+	font-weight: 500;
+}
+
+.token-meta {
+	font-size: 0.8rem;
+	color: var(--color-text-secondary, #888);
+}
+
+.expiry-warning {
+	font-size: 0.75rem;
+	color: var(--color-warning, #e67e22);
+	font-weight: 500;
+}
+
+.btn-revoke {
+	padding: 0.3rem 0.75rem;
+	font-size: 0.85rem;
+	color: var(--color-danger, #c0392b);
+	border: 1px solid currentColor;
+	background: none;
+	border-radius: 4px;
+	cursor: pointer;
+	white-space: nowrap;
+}
+
+.btn-revoke:hover {
+	background: var(--color-danger, #c0392b);
+	color: white;
+}
+
+.docs-link {
+	margin-top: 1rem;
+	font-size: 0.85rem;
+}
+</style>

--- a/src/lib/server/api/v1-access.ts
+++ b/src/lib/server/api/v1-access.ts
@@ -1,0 +1,40 @@
+/**
+ * Access-check helpers for v1 API routes.
+ */
+import { and, eq } from "drizzle-orm";
+import { db } from "../db/index.js";
+import { boards, seriesMembers } from "../db/schema.js";
+
+export async function requireSeriesMember(
+	userId: string,
+	seriesId: string,
+): Promise<{ role: string } | null> {
+	const [member] = await db
+		.select({ role: seriesMembers.role })
+		.from(seriesMembers)
+		.where(and(eq(seriesMembers.userId, userId), eq(seriesMembers.seriesId, seriesId)))
+		.limit(1);
+	return member ?? null;
+}
+
+/**
+ * Returns the seriesId for a board if the user is a member, null otherwise.
+ * Returns undefined if the board doesn't exist.
+ */
+export async function getBoardSeriesForUser(
+	userId: string,
+	boardId: string,
+): Promise<{ seriesId: string } | "not_found" | "forbidden"> {
+	const [board] = await db
+		.select({ seriesId: boards.seriesId })
+		.from(boards)
+		.where(eq(boards.id, boardId))
+		.limit(1);
+
+	if (!board) return "not_found";
+
+	const member = await requireSeriesMember(userId, board.seriesId);
+	if (!member) return "forbidden";
+
+	return { seriesId: board.seriesId };
+}

--- a/src/lib/server/auth/api-token.ts
+++ b/src/lib/server/auth/api-token.ts
@@ -1,0 +1,48 @@
+import crypto from "node:crypto";
+import { and, eq, gt } from "drizzle-orm";
+import { db } from "../db/index.js";
+import { apiTokens, users } from "../db/schema.js";
+
+export const TOKEN_PREFIX = "tb_";
+export const TOKEN_TTL_MS = 90 * 24 * 60 * 60 * 1000; // 90 days
+
+export function generateToken(): { token: string; hash: string } {
+	const bytes = crypto.randomBytes(32);
+	const token = TOKEN_PREFIX + bytes.toString("hex");
+	const hash = hashToken(token);
+	return { token, hash };
+}
+
+export function hashToken(rawToken: string): string {
+	return crypto.createHash("sha256").update(rawToken).digest("hex");
+}
+
+export async function validateApiToken(
+	rawToken: string,
+): Promise<{ userId: string; email: string } | null> {
+	if (!rawToken.startsWith(TOKEN_PREFIX)) return null;
+
+	const hash = hashToken(rawToken);
+	const now = Date.now();
+
+	const [record] = await db
+		.select({
+			tokenId: apiTokens.id,
+			userId: apiTokens.userId,
+			userEmail: users.email,
+		})
+		.from(apiTokens)
+		.innerJoin(users, eq(users.id, apiTokens.userId))
+		.where(and(eq(apiTokens.tokenHash, hash), gt(apiTokens.expiresAt, now)))
+		.limit(1);
+
+	if (!record) return null;
+
+	// Fire-and-forget last-used update — don't block the request
+	db.update(apiTokens)
+		.set({ lastUsedAt: now })
+		.where(eq(apiTokens.id, record.tokenId))
+		.catch(() => {});
+
+	return { userId: record.userId, email: record.userEmail };
+}

--- a/src/lib/server/auth/index.ts
+++ b/src/lib/server/auth/index.ts
@@ -1,5 +1,6 @@
 import type { RequestEvent } from "@sveltejs/kit";
 import { redirect } from "@sveltejs/kit";
+import { validateApiToken } from "./api-token.js";
 import type { SessionData } from "./session.js";
 import { getSession } from "./session.js";
 
@@ -41,6 +42,29 @@ export function requireUserForApi(event: RequestEvent): SessionData {
 		});
 	}
 	return user;
+}
+
+/**
+ * Auth check for v1 API routes. Accepts either a Bearer API token or a session cookie.
+ * Must be awaited — token validation is async (DB lookup).
+ */
+export async function requireApiV1Auth(
+	event: RequestEvent,
+): Promise<SessionData> {
+	const authHeader = event.request.headers.get("Authorization");
+	if (authHeader?.startsWith("Bearer ")) {
+		const rawToken = authHeader.slice(7).trim();
+		const user = await validateApiToken(rawToken);
+		if (user) return { userId: user.userId, email: user.email, expiresAt: 0 };
+	}
+
+	const sessionUser = getUser(event);
+	if (sessionUser) return sessionUser;
+
+	throw new Response(JSON.stringify({ success: false, error: "Unauthorized" }), {
+		status: 401,
+		headers: { "Content-Type": "application/json" },
+	});
 }
 
 export function setSessionCookie(event: RequestEvent, sessionId: string): void {

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -519,7 +519,7 @@ export const scorecardDatasources = table(
 			.references(() => scorecards.id, { onDelete: "cascade" }),
 		name: text("name").notNull(),
 		seq: integer("seq").notNull(),
-		sourceType: text("source_type").notNull().$type<"paste" | "api">(),
+		sourceType: text("source_type").notNull().$type<"paste" | "api" | "ai">(),
 		apiConfig: text("api_config"), // JSON: {url, auth_type, credentials_encrypted}
 		dataSchema: text("data_schema"), // JSON: describes expected data shape
 		rules: text("rules").notNull(), // JSON: array of rule objects
@@ -585,6 +585,27 @@ export const sceneScorecardResults = table(
 		sceneScorecardIdx: indexField(
 			"scene_scorecard_results_scene_scorecard_idx",
 		).on(table.sceneScorecardId),
+	}),
+);
+
+// API Tokens - for programmatic / AI access to the v1 REST API
+// Token hashes are SHA-256 of the raw tb_* token; raw tokens are never stored.
+export const apiTokens = table(
+	"api_tokens",
+	{
+		id: text("id").primaryKey(),
+		userId: text("user_id")
+			.notNull()
+			.references(() => users.id, { onDelete: "cascade" }),
+		tokenHash: text("token_hash").notNull(),
+		label: text("label").notNull(),
+		expiresAt: bigintField("expires_at").notNull(),
+		lastUsedAt: bigintField("last_used_at"),
+		createdAt: bigintField("created_at").notNull(),
+	},
+	(table) => ({
+		tokenHashUnique: unique("api_tokens_token_hash_unique").on(table.tokenHash),
+		userIdIdx: indexField("api_tokens_user_id_idx").on(table.userId),
 	}),
 );
 
@@ -793,6 +814,14 @@ export const usersRelations = relations(users, ({ many }) => ({
 	presence: many(presence),
 	authenticators: many(userAuthenticators),
 	quadrantPositions: many(quadrantPositions),
+	apiTokens: many(apiTokens),
+}));
+
+export const apiTokensRelations = relations(apiTokens, ({ one }) => ({
+	user: one(users, {
+		fields: [apiTokens.userId],
+		references: [users.id],
+	}),
 }));
 
 export const userAuthenticatorsRelations = relations(

--- a/src/lib/server/repositories/api-tokens.ts
+++ b/src/lib/server/repositories/api-tokens.ts
@@ -1,0 +1,68 @@
+import { and, eq, gt, lt } from "drizzle-orm";
+import { v4 as uuidv4 } from "uuid";
+import { generateToken, TOKEN_TTL_MS } from "../auth/api-token.js";
+import { db } from "../db/index.js";
+import { apiTokens } from "../db/schema.js";
+
+export async function createApiToken(userId: string, label: string) {
+	const id = uuidv4();
+	const { token, hash } = generateToken();
+	const now = Date.now();
+	const expiresAt = now + TOKEN_TTL_MS;
+
+	await db.insert(apiTokens).values({
+		id,
+		userId,
+		tokenHash: hash,
+		label,
+		expiresAt,
+		lastUsedAt: null,
+		createdAt: now,
+	});
+
+	return {
+		rawToken: token,
+		tokenInfo: {
+			id,
+			label,
+			expiresAt,
+			lastUsedAt: null,
+			createdAt: now,
+		},
+	};
+}
+
+export async function listApiTokens(userId: string) {
+	const now = Date.now();
+	return db
+		.select({
+			id: apiTokens.id,
+			label: apiTokens.label,
+			expiresAt: apiTokens.expiresAt,
+			lastUsedAt: apiTokens.lastUsedAt,
+			createdAt: apiTokens.createdAt,
+		})
+		.from(apiTokens)
+		.where(and(eq(apiTokens.userId, userId), gt(apiTokens.expiresAt, now)))
+		.orderBy(apiTokens.createdAt);
+}
+
+export async function revokeApiToken(
+	tokenId: string,
+	userId: string,
+): Promise<boolean> {
+	const result = await db
+		.delete(apiTokens)
+		.where(and(eq(apiTokens.id, tokenId), eq(apiTokens.userId, userId)));
+
+	// Drizzle returns rowsAffected in different shapes for pg vs sqlite
+	const rows =
+		(result as any).rowsAffected ??
+		(result as any).rowCount ??
+		(Array.isArray(result) ? result.length : 0);
+	return rows > 0;
+}
+
+export async function cleanupExpiredTokens(): Promise<void> {
+	await db.delete(apiTokens).where(lt(apiTokens.expiresAt, Date.now()));
+}

--- a/src/routes/api/v1/boards/[id]/+server.ts
+++ b/src/routes/api/v1/boards/[id]/+server.ts
@@ -1,0 +1,94 @@
+import { json } from "@sveltejs/kit";
+import { eq, sql } from "drizzle-orm";
+import { requireApiV1Auth } from "$lib/server/auth/index.js";
+import { getBoardSeriesForUser } from "$lib/server/api/v1-access.js";
+import { db } from "$lib/server/db/index.js";
+import { boards, cards, columns, sceneFlags, scenes } from "$lib/server/db/schema.js";
+import type { RequestHandler } from "./$types";
+
+export const GET: RequestHandler = async (event) => {
+	try {
+		const user = await requireApiV1Auth(event);
+		const boardId = event.params.id;
+
+		const access = await getBoardSeriesForUser(user.userId, boardId);
+		if (access === "not_found")
+			return json({ success: false, error: "Board not found" }, { status: 404 });
+		if (access === "forbidden")
+			return json({ success: false, error: "Access denied" }, { status: 403 });
+
+		const [[board], boardColumns, boardScenes, boardCards] = await Promise.all([
+			db
+				.select({
+					id: boards.id,
+					seriesId: boards.seriesId,
+					name: boards.name,
+					status: boards.status,
+					meetingDate: boards.meetingDate,
+					blameFreeMode: boards.blameFreeMode,
+					votingAllocation: boards.votingAllocation,
+					votingEnabled: boards.votingEnabled,
+					currentSceneId: boards.currentSceneId,
+					createdAt: boards.createdAt,
+				})
+				.from(boards)
+				.where(eq(boards.id, boardId))
+				.limit(1),
+
+			db
+				.select({ id: columns.id, title: columns.title, seq: columns.seq })
+				.from(columns)
+				.where(eq(columns.boardId, boardId))
+				.orderBy(columns.seq),
+
+			db
+				.select({ id: scenes.id, title: scenes.title, mode: scenes.mode, seq: scenes.seq })
+				.from(scenes)
+				.where(eq(scenes.boardId, boardId))
+				.orderBy(scenes.seq),
+
+			db
+				.select({
+					id: cards.id,
+					columnId: cards.columnId,
+					content: cards.content,
+					groupId: cards.groupId,
+					voteCount: sql<number>`(SELECT COUNT(*) FROM votes WHERE votes.card_id = ${cards.id})`,
+					commentCount: sql<number>`(SELECT COUNT(*) FROM comments WHERE comments.card_id = ${cards.id} AND comments.is_reaction = 0)`,
+					createdAt: cards.createdAt,
+				})
+				.from(cards)
+				.innerJoin(columns, eq(columns.id, cards.columnId))
+				.where(eq(columns.boardId, boardId))
+				.orderBy(cards.seq, cards.createdAt),
+		]);
+
+		// Fetch scene flags for all scenes in one query
+		const flagMap = new Map<string, string[]>();
+		if (boardScenes.length > 0) {
+			const flagRows = await db
+				.select({ sceneId: sceneFlags.sceneId, flag: sceneFlags.flag })
+				.from(sceneFlags)
+				.innerJoin(scenes, eq(scenes.id, sceneFlags.sceneId))
+				.where(eq(scenes.boardId, boardId));
+
+			for (const row of flagRows) {
+				if (!flagMap.has(row.sceneId)) flagMap.set(row.sceneId, []);
+				flagMap.get(row.sceneId)!.push(row.flag);
+			}
+		}
+
+		return json({
+			success: true,
+			board: {
+				...board,
+				columns: boardColumns,
+				scenes: boardScenes.map((s) => ({ ...s, flags: flagMap.get(s.id) ?? [] })),
+				cards: boardCards,
+			},
+		});
+	} catch (err) {
+		if (err instanceof Response) throw err;
+		return json({ success: false, error: "Failed to fetch board" }, { status: 500 });
+	}
+};

--- a/src/routes/api/v1/boards/[id]/agreements/+server.ts
+++ b/src/routes/api/v1/boards/[id]/agreements/+server.ts
@@ -1,0 +1,48 @@
+import { json } from "@sveltejs/kit";
+import { and, eq } from "drizzle-orm";
+import { requireApiV1Auth } from "$lib/server/auth/index.js";
+import { getBoardSeriesForUser } from "$lib/server/api/v1-access.js";
+import { db } from "$lib/server/db/index.js";
+import { agreements, users } from "$lib/server/db/schema.js";
+import type { RequestHandler } from "./$types";
+
+export const GET: RequestHandler = async (event) => {
+	try {
+		const user = await requireApiV1Auth(event);
+		const boardId = event.params.id;
+
+		const access = await getBoardSeriesForUser(user.userId, boardId);
+		if (access === "not_found")
+			return json({ success: false, error: "Board not found" }, { status: 404 });
+		if (access === "forbidden")
+			return json({ success: false, error: "Access denied" }, { status: 403 });
+
+		const completedParam = event.url.searchParams.get("completed");
+		const completedFilter =
+			completedParam === "true" ? true : completedParam === "false" ? false : null;
+
+		const result = await db
+			.select({
+				id: agreements.id,
+				content: agreements.content,
+				completed: agreements.completed,
+				createdAt: agreements.createdAt,
+				completedAt: agreements.completedAt,
+				completedByName: users.name,
+			})
+			.from(agreements)
+			.leftJoin(users, eq(users.id, agreements.completedByUserId))
+			.where(
+				and(
+					eq(agreements.boardId, boardId),
+					completedFilter !== null ? eq(agreements.completed, completedFilter) : undefined,
+				),
+			)
+			.orderBy(agreements.createdAt);
+
+		return json({ success: true, agreements: result });
+	} catch (err) {
+		if (err instanceof Response) throw err;
+		return json({ success: false, error: "Failed to fetch agreements" }, { status: 500 });
+	}
+};

--- a/src/routes/api/v1/boards/[id]/cards/+server.ts
+++ b/src/routes/api/v1/boards/[id]/cards/+server.ts
@@ -1,0 +1,44 @@
+import { json } from "@sveltejs/kit";
+import { eq, sql } from "drizzle-orm";
+import { requireApiV1Auth } from "$lib/server/auth/index.js";
+import { getBoardSeriesForUser } from "$lib/server/api/v1-access.js";
+import { db } from "$lib/server/db/index.js";
+import { cards, columns } from "$lib/server/db/schema.js";
+import type { RequestHandler } from "./$types";
+
+export const GET: RequestHandler = async (event) => {
+	try {
+		const user = await requireApiV1Auth(event);
+		const boardId = event.params.id;
+
+		const access = await getBoardSeriesForUser(user.userId, boardId);
+		if (access === "not_found")
+			return json({ success: false, error: "Board not found" }, { status: 404 });
+		if (access === "forbidden")
+			return json({ success: false, error: "Access denied" }, { status: 403 });
+
+		const result = await db
+			.select({
+				id: cards.id,
+				columnId: cards.columnId,
+				columnTitle: columns.title,
+				content: cards.content,
+				notes: cards.notes,
+				groupId: cards.groupId,
+				isGroupLead: cards.isGroupLead,
+				seq: cards.seq,
+				voteCount: sql<number>`(SELECT COUNT(*) FROM votes WHERE votes.card_id = ${cards.id})`,
+				commentCount: sql<number>`(SELECT COUNT(*) FROM comments WHERE comments.card_id = ${cards.id} AND comments.is_reaction = 0)`,
+				createdAt: cards.createdAt,
+			})
+			.from(cards)
+			.innerJoin(columns, eq(columns.id, cards.columnId))
+			.where(eq(columns.boardId, boardId))
+			.orderBy(cards.seq, cards.createdAt);
+
+		return json({ success: true, cards: result });
+	} catch (err) {
+		if (err instanceof Response) throw err;
+		return json({ success: false, error: "Failed to fetch cards" }, { status: 500 });
+	}
+};

--- a/src/routes/api/v1/boards/[id]/scorecard-results/+server.ts
+++ b/src/routes/api/v1/boards/[id]/scorecard-results/+server.ts
@@ -1,0 +1,65 @@
+import { json } from "@sveltejs/kit";
+import { eq } from "drizzle-orm";
+import { requireApiV1Auth } from "$lib/server/auth/index.js";
+import { getBoardSeriesForUser } from "$lib/server/api/v1-access.js";
+import { db } from "$lib/server/db/index.js";
+import {
+	sceneScorecardResults,
+	sceneScorecards,
+	scorecardDatasources,
+	scorecards,
+	scenes,
+} from "$lib/server/db/schema.js";
+import type { RequestHandler } from "./$types";
+
+export const GET: RequestHandler = async (event) => {
+	try {
+		const user = await requireApiV1Auth(event);
+		const boardId = event.params.id;
+
+		const access = await getBoardSeriesForUser(user.userId, boardId);
+		if (access === "not_found")
+			return json({ success: false, error: "Board not found" }, { status: 404 });
+		if (access === "forbidden")
+			return json({ success: false, error: "Access denied" }, { status: 403 });
+
+		const results = await db
+			.select({
+				sceneScorecardId: sceneScorecardResults.sceneScorecardId,
+				sceneId: scenes.id,
+				sceneTitle: scenes.title,
+				scorecardName: scorecards.name,
+				datasourceName: scorecardDatasources.name,
+				section: sceneScorecardResults.section,
+				title: sceneScorecardResults.title,
+				primaryValue: sceneScorecardResults.primaryValue,
+				secondaryValues: sceneScorecardResults.secondaryValues,
+				severity: sceneScorecardResults.severity,
+				seq: sceneScorecardResults.seq,
+			})
+			.from(sceneScorecardResults)
+			.innerJoin(
+				sceneScorecards,
+				eq(sceneScorecards.id, sceneScorecardResults.sceneScorecardId),
+			)
+			.innerJoin(scenes, eq(scenes.id, sceneScorecards.sceneId))
+			.innerJoin(scorecards, eq(scorecards.id, sceneScorecards.scorecardId))
+			.innerJoin(
+				scorecardDatasources,
+				eq(scorecardDatasources.id, sceneScorecardResults.datasourceId),
+			)
+			.where(eq(scenes.boardId, boardId))
+			.orderBy(scenes.seq, sceneScorecardResults.seq);
+
+		// Parse secondaryValues JSON
+		const parsedResults = results.map((r) => ({
+			...r,
+			secondaryValues: r.secondaryValues ? JSON.parse(r.secondaryValues) : null,
+		}));
+
+		return json({ success: true, results: parsedResults });
+	} catch (err) {
+		if (err instanceof Response) throw err;
+		return json({ success: false, error: "Failed to fetch scorecard results" }, { status: 500 });
+	}
+};

--- a/src/routes/api/v1/datasources/[id]/inject/+server.ts
+++ b/src/routes/api/v1/datasources/[id]/inject/+server.ts
@@ -1,0 +1,124 @@
+import { json } from "@sveltejs/kit";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+import { v4 as uuidv4 } from "uuid";
+import { requireApiV1Auth } from "$lib/server/auth/index.js";
+import { requireSeriesMember } from "$lib/server/api/v1-access.js";
+import { db } from "$lib/server/db/index.js";
+import {
+	scorecardDatasources,
+	scorecards,
+	sceneScorecards,
+	sceneScorecardResults,
+} from "$lib/server/db/schema.js";
+import type { RequestHandler } from "./$types";
+
+const injectSchema = z.object({
+	data: z
+		.array(
+			z.object({
+				section: z.string().min(1).max(100),
+				title: z.string().min(1).max(200),
+				primaryValue: z.string().max(200).optional().nullable(),
+				secondaryValues: z.record(z.string()).optional().nullable(),
+				severity: z.enum(["info", "warning", "critical"]).optional().default("info"),
+				sourceData: z.any().optional().nullable(),
+			}),
+		)
+		.min(1)
+		.max(500),
+});
+
+export const POST: RequestHandler = async (event) => {
+	try {
+		const user = await requireApiV1Auth(event);
+		const datasourceId = event.params.id;
+
+		// Load datasource + its scorecard + series for access check
+		const [datasource] = await db
+			.select({
+				id: scorecardDatasources.id,
+				sourceType: scorecardDatasources.sourceType,
+				scorecardId: scorecardDatasources.scorecardId,
+				seriesId: scorecards.seriesId,
+			})
+			.from(scorecardDatasources)
+			.innerJoin(scorecards, eq(scorecards.id, scorecardDatasources.scorecardId))
+			.where(eq(scorecardDatasources.id, datasourceId))
+			.limit(1);
+
+		if (!datasource)
+			return json({ success: false, error: "Datasource not found" }, { status: 404 });
+
+		if (datasource.sourceType !== "ai")
+			return json(
+				{ success: false, error: "Access denied: datasource is not of type 'ai'" },
+				{ status: 403 },
+			);
+
+		const member = await requireSeriesMember(user.userId, datasource.seriesId);
+		if (!member)
+			return json({ success: false, error: "Access denied" }, { status: 403 });
+
+		const body = await event.request.json();
+		const { data } = injectSchema.parse(body);
+
+		// Store as pending injection on the datasource's apiConfig field.
+		// The next scorecard collection pass will pick this up.
+		await db
+			.update(scorecardDatasources)
+			.set({
+				apiConfig: JSON.stringify({ injected: data, injectedAt: new Date().toISOString() }),
+				updatedAt: new Date().toISOString(),
+			})
+			.where(eq(scorecardDatasources.id, datasourceId));
+
+		// Also immediately write results into any active scene_scorecards for this datasource
+		// so facilitators see them without re-running collection.
+		const activeScorecards = await db
+			.select({ id: sceneScorecards.id })
+			.from(sceneScorecards)
+			.where(eq(sceneScorecards.scorecardId, datasource.scorecardId));
+
+		for (const sc of activeScorecards) {
+			// Remove prior AI-injected results for this datasource+sceneScorecard
+			await db
+				.delete(sceneScorecardResults)
+				.where(
+					and(
+						eq(sceneScorecardResults.sceneScorecardId, sc.id),
+						eq(sceneScorecardResults.datasourceId, datasourceId),
+					),
+				);
+
+			// Insert fresh results
+			for (let i = 0; i < data.length; i++) {
+				const item = data[i];
+				await db.insert(sceneScorecardResults).values({
+					id: uuidv4(),
+					sceneScorecardId: sc.id,
+					datasourceId,
+					section: item.section,
+					title: item.title,
+					primaryValue: item.primaryValue ?? null,
+					secondaryValues: item.secondaryValues ? JSON.stringify(item.secondaryValues) : null,
+					severity: item.severity ?? "info",
+					sourceData: item.sourceData ? JSON.stringify(item.sourceData) : null,
+					seq: i + 1,
+				});
+			}
+		}
+
+		return json({ success: true, injected: data.length });
+	} catch (err) {
+		if (err instanceof Response) throw err;
+		if (err instanceof z.ZodError) {
+			return json(
+				{ success: false, error: "Invalid input", details: err.errors },
+				{ status: 400 },
+			);
+		}
+		console.error("[v1 datasource inject]", err);
+		return json({ success: false, error: "Failed to inject data" }, { status: 500 });
+	}
+};

--- a/src/routes/api/v1/openapi.json/+server.ts
+++ b/src/routes/api/v1/openapi.json/+server.ts
@@ -1,0 +1,406 @@
+import { json } from "@sveltejs/kit";
+import type { RequestHandler } from "./$types";
+
+export const GET: RequestHandler = () => {
+	const spec = {
+		openapi: "3.1.0",
+		info: {
+			title: "Teambeat API",
+			version: "1.0.0",
+			description:
+				"Programmatic access to Teambeat boards, series, health data, and scorecards. Intended for AI and automation clients.",
+		},
+		servers: [{ url: "/api/v1", description: "Teambeat v1 API" }],
+		security: [{ BearerAuth: [] }],
+		components: {
+			securitySchemes: {
+				BearerAuth: {
+					type: "http",
+					scheme: "bearer",
+					description: "API token obtained from your Teambeat profile page (prefix: tb_). Valid for 90 days.",
+				},
+			},
+			schemas: {
+				Error: {
+					type: "object",
+					properties: {
+						success: { type: "boolean", example: false },
+						error: { type: "string" },
+						details: { type: "array", items: { type: "object" } },
+					},
+					required: ["success", "error"],
+				},
+				Token: {
+					type: "object",
+					properties: {
+						id: { type: "string", format: "uuid" },
+						label: { type: "string" },
+						expiresAt: { type: "integer", description: "Unix milliseconds" },
+						lastUsedAt: { type: "integer", nullable: true },
+						createdAt: { type: "integer" },
+					},
+				},
+				Series: {
+					type: "object",
+					properties: {
+						id: { type: "string", format: "uuid" },
+						name: { type: "string" },
+						slug: { type: "string", nullable: true },
+						description: { type: "string", nullable: true },
+						role: { type: "string", enum: ["admin", "facilitator", "member"] },
+						createdAt: { type: "string", format: "date-time" },
+					},
+				},
+				BoardSummary: {
+					type: "object",
+					properties: {
+						id: { type: "string", format: "uuid" },
+						name: { type: "string" },
+						status: { type: "string", enum: ["draft", "active", "completed", "archived"] },
+						meetingDate: { type: "string", format: "date", nullable: true },
+						createdAt: { type: "string", format: "date-time" },
+						sceneCount: { type: "integer" },
+						cardCount: { type: "integer" },
+						agreementCount: { type: "integer" },
+					},
+				},
+				Board: {
+					type: "object",
+					properties: {
+						id: { type: "string", format: "uuid" },
+						seriesId: { type: "string", format: "uuid" },
+						name: { type: "string" },
+						status: { type: "string", enum: ["draft", "active", "completed", "archived"] },
+						meetingDate: { type: "string", format: "date", nullable: true },
+						blameFreeMode: { type: "boolean" },
+						votingAllocation: { type: "integer" },
+						votingEnabled: { type: "boolean" },
+						currentSceneId: { type: "string", nullable: true },
+						columns: { type: "array", items: { "$ref": "#/components/schemas/Column" } },
+						scenes: { type: "array", items: { "$ref": "#/components/schemas/Scene" } },
+						cards: { type: "array", items: { "$ref": "#/components/schemas/CardSummary" } },
+						createdAt: { type: "string", format: "date-time" },
+					},
+				},
+				Column: {
+					type: "object",
+					properties: {
+						id: { type: "string", format: "uuid" },
+						title: { type: "string" },
+						seq: { type: "integer" },
+					},
+				},
+				Scene: {
+					type: "object",
+					properties: {
+						id: { type: "string", format: "uuid" },
+						title: { type: "string" },
+						mode: { type: "string", enum: ["columns", "present", "review", "agreements", "scorecard", "static", "survey", "quadrant"] },
+						seq: { type: "integer" },
+						flags: { type: "array", items: { type: "string" } },
+					},
+				},
+				CardSummary: {
+					type: "object",
+					properties: {
+						id: { type: "string", format: "uuid" },
+						columnId: { type: "string", format: "uuid" },
+						columnTitle: { type: "string" },
+						content: { type: "string" },
+						notes: { type: "string", nullable: true },
+						voteCount: { type: "integer" },
+						commentCount: { type: "integer" },
+						groupId: { type: "string", nullable: true },
+						isGroupLead: { type: "boolean" },
+						seq: { type: "integer" },
+						createdAt: { type: "string", format: "date-time" },
+					},
+				},
+				Agreement: {
+					type: "object",
+					properties: {
+						id: { type: "string", format: "uuid" },
+						content: { type: "string" },
+						completed: { type: "boolean" },
+						boardId: { type: "string", format: "uuid" },
+						boardName: { type: "string" },
+						meetingDate: { type: "string", format: "date", nullable: true },
+						createdAt: { type: "string", format: "date-time" },
+						completedAt: { type: "string", nullable: true },
+						completedByName: { type: "string", nullable: true },
+					},
+				},
+				ScorecardResult: {
+					type: "object",
+					properties: {
+						sceneScorecardId: { type: "string", format: "uuid" },
+						sceneId: { type: "string", format: "uuid" },
+						sceneTitle: { type: "string" },
+						scorecardName: { type: "string" },
+						datasourceName: { type: "string" },
+						section: { type: "string" },
+						title: { type: "string" },
+						primaryValue: { type: "string", nullable: true },
+						secondaryValues: { type: "object", nullable: true, additionalProperties: { type: "string" } },
+						severity: { type: "string", enum: ["info", "warning", "critical"] },
+						seq: { type: "integer" },
+					},
+				},
+			},
+		},
+		paths: {
+			"/tokens": {
+				get: {
+					summary: "List API tokens",
+					operationId: "listTokens",
+					tags: ["Tokens"],
+					responses: {
+						200: { description: "Token list", content: { "application/json": { schema: { type: "object", properties: { success: { type: "boolean" }, tokens: { type: "array", items: { "$ref": "#/components/schemas/Token" } } } } } } },
+						401: { description: "Unauthorized" },
+					},
+				},
+				post: {
+					summary: "Create an API token",
+					operationId: "createToken",
+					tags: ["Tokens"],
+					requestBody: {
+						required: true,
+						content: { "application/json": { schema: { type: "object", required: ["label"], properties: { label: { type: "string", minLength: 1, maxLength: 100, description: "Human-readable label for this token" } } } } },
+					},
+					responses: {
+						201: { description: "Token created — raw token shown only once", content: { "application/json": { schema: { type: "object", properties: { success: { type: "boolean" }, token: { type: "string", description: "Raw token value — store this securely" }, tokenInfo: { "$ref": "#/components/schemas/Token" } } } } } },
+						400: { description: "Validation error" },
+						401: { description: "Unauthorized" },
+					},
+				},
+			},
+			"/tokens/{id}": {
+				delete: {
+					summary: "Revoke a token",
+					operationId: "revokeToken",
+					tags: ["Tokens"],
+					parameters: [{ name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } }],
+					responses: {
+						200: { description: "Token revoked" },
+						401: { description: "Unauthorized" },
+						404: { description: "Token not found" },
+					},
+				},
+			},
+			"/series": {
+				get: {
+					summary: "List series",
+					operationId: "listSeries",
+					tags: ["Series"],
+					description: "Returns all series the authenticated user is a member of.",
+					responses: {
+						200: { description: "Series list", content: { "application/json": { schema: { type: "object", properties: { success: { type: "boolean" }, series: { type: "array", items: { "$ref": "#/components/schemas/Series" } } } } } } },
+						401: { description: "Unauthorized" },
+					},
+				},
+			},
+			"/series/{id}/boards": {
+				get: {
+					summary: "List boards in a series",
+					operationId: "listBoards",
+					tags: ["Series", "Boards"],
+					parameters: [
+						{ name: "id", in: "path", required: true, schema: { type: "string" } },
+						{ name: "status", in: "query", schema: { type: "string", enum: ["draft", "active", "completed", "archived"] } },
+						{ name: "limit", in: "query", schema: { type: "integer", default: 20, minimum: 1, maximum: 100 } },
+						{ name: "offset", in: "query", schema: { type: "integer", default: 0 } },
+					],
+					responses: {
+						200: { description: "Board list with summary counts" },
+						401: { description: "Unauthorized" },
+						403: { description: "Access denied" },
+						404: { description: "Series not found" },
+					},
+				},
+				post: {
+					summary: "Create a board (optionally pre-populated)",
+					operationId: "createBoard",
+					tags: ["Series", "Boards"],
+					description: "Creates a board with optional columns, scenes, and seed cards in a single atomic operation. Ideal for AI clients that want to scaffold a meeting from prior data.",
+					parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+					requestBody: {
+						required: true,
+						content: {
+							"application/json": {
+								schema: {
+									type: "object",
+									required: ["name"],
+									properties: {
+										name: { type: "string", minLength: 1, maxLength: 100 },
+										meetingDate: { type: "string", format: "date" },
+										blameFreeMode: { type: "boolean", default: false },
+										votingAllocation: { type: "integer", minimum: 0, maximum: 10, default: 3 },
+										columns: { type: "array", maxItems: 20, items: { type: "object", required: ["title"], properties: { title: { type: "string" }, description: { type: "string" }, seq: { type: "integer" } } } },
+										scenes: { type: "array", maxItems: 20, items: { type: "object", required: ["title", "mode"], properties: { title: { type: "string" }, mode: { type: "string", enum: ["columns", "present", "review", "agreements", "scorecard", "static", "survey", "quadrant"] }, seq: { type: "integer" }, flags: { type: "array", items: { type: "string" } } } } },
+										cards: { type: "array", items: { type: "object", required: ["columnTitle", "content"], properties: { columnTitle: { type: "string", description: "Must match a column title in this request" }, content: { type: "string" }, notes: { type: "string" } } } },
+									},
+								},
+							},
+						},
+					},
+					responses: {
+						201: { description: "Board created" },
+						400: { description: "Validation error or unknown column reference" },
+						401: { description: "Unauthorized" },
+						403: { description: "Access denied" },
+						404: { description: "Series not found" },
+					},
+				},
+			},
+			"/series/{id}/agreements": {
+				get: {
+					summary: "All action items across a series",
+					operationId: "listSeriesAgreements",
+					tags: ["Series", "Agreements"],
+					parameters: [
+						{ name: "id", in: "path", required: true, schema: { type: "string" } },
+						{ name: "completed", in: "query", schema: { type: "boolean" } },
+						{ name: "limit", in: "query", schema: { type: "integer", default: 50, minimum: 1, maximum: 200 } },
+						{ name: "offset", in: "query", schema: { type: "integer", default: 0 } },
+					],
+					responses: {
+						200: { description: "Agreement list with board context" },
+						401: { description: "Unauthorized" },
+						403: { description: "Access denied" },
+						404: { description: "Series not found" },
+					},
+				},
+			},
+			"/series/{id}/health-summary": {
+				get: {
+					summary: "Health check trends over time",
+					operationId: "healthSummary",
+					tags: ["Series", "Health"],
+					description: "Returns survey question response distributions across recent boards, grouped by threadId for longitudinal tracking.",
+					parameters: [
+						{ name: "id", in: "path", required: true, schema: { type: "string" } },
+						{ name: "limit", in: "query", schema: { type: "integer", default: 10, minimum: 1, maximum: 50, description: "Number of most-recent boards to include" } },
+					],
+					responses: {
+						200: { description: "Health trends per question thread" },
+						401: { description: "Unauthorized" },
+						403: { description: "Access denied" },
+						404: { description: "Series not found" },
+					},
+				},
+			},
+			"/boards/{id}": {
+				get: {
+					summary: "Get full board detail",
+					operationId: "getBoard",
+					tags: ["Boards"],
+					parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+					responses: {
+						200: { description: "Board with columns, scenes, cards" },
+						401: { description: "Unauthorized" },
+						403: { description: "Access denied" },
+						404: { description: "Board not found" },
+					},
+				},
+			},
+			"/boards/{id}/cards": {
+				get: {
+					summary: "Get all cards in a board",
+					operationId: "getBoardCards",
+					tags: ["Boards", "Cards"],
+					parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+					responses: {
+						200: { description: "Cards with vote and comment counts" },
+						401: { description: "Unauthorized" },
+						403: { description: "Access denied" },
+						404: { description: "Board not found" },
+					},
+				},
+			},
+			"/boards/{id}/agreements": {
+				get: {
+					summary: "Get action items for a board",
+					operationId: "getBoardAgreements",
+					tags: ["Boards", "Agreements"],
+					parameters: [
+						{ name: "id", in: "path", required: true, schema: { type: "string" } },
+						{ name: "completed", in: "query", schema: { type: "boolean" } },
+					],
+					responses: {
+						200: { description: "Agreements list" },
+						401: { description: "Unauthorized" },
+						403: { description: "Access denied" },
+						404: { description: "Board not found" },
+					},
+				},
+			},
+			"/boards/{id}/scorecard-results": {
+				get: {
+					summary: "Get processed scorecard results for a board",
+					operationId: "getScorecardResults",
+					tags: ["Boards", "Scorecards"],
+					parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+					responses: {
+						200: { description: "Scorecard results with scene and datasource context" },
+						401: { description: "Unauthorized" },
+						403: { description: "Access denied" },
+						404: { description: "Board not found" },
+					},
+				},
+			},
+			"/datasources/{id}/inject": {
+				post: {
+					summary: "Push AI-generated findings into a datasource",
+					operationId: "injectDatasource",
+					tags: ["Scorecards", "AI"],
+					description: "Push pre-processed scorecard results from an AI client. The datasource must have sourceType='ai'. Results are immediately visible in any active scene scorecard.",
+					parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+					requestBody: {
+						required: true,
+						content: {
+							"application/json": {
+								schema: {
+									type: "object",
+									required: ["data"],
+									properties: {
+										data: {
+											type: "array",
+											minItems: 1,
+											maxItems: 500,
+											items: {
+												type: "object",
+												required: ["section", "title"],
+												properties: {
+													section: { type: "string", maxLength: 100 },
+													title: { type: "string", maxLength: 200 },
+													primaryValue: { type: "string", nullable: true },
+													secondaryValues: { type: "object", nullable: true, additionalProperties: { type: "string" } },
+													severity: { type: "string", enum: ["info", "warning", "critical"], default: "info" },
+													sourceData: { nullable: true, description: "Raw evidence object" },
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					responses: {
+						200: { description: "Injection successful", content: { "application/json": { schema: { type: "object", properties: { success: { type: "boolean" }, injected: { type: "integer", description: "Number of results written" } } } } } },
+						400: { description: "Validation error" },
+						401: { description: "Unauthorized" },
+						403: { description: "Access denied or datasource is not type 'ai'" },
+						404: { description: "Datasource not found" },
+					},
+				},
+			},
+		},
+	};
+
+	return json(spec, {
+		headers: {
+			"Access-Control-Allow-Origin": "*",
+			"Cache-Control": "public, max-age=3600",
+		},
+	});
+};

--- a/src/routes/api/v1/series/+server.ts
+++ b/src/routes/api/v1/series/+server.ts
@@ -1,0 +1,15 @@
+import { json } from "@sveltejs/kit";
+import { requireApiV1Auth } from "$lib/server/auth/index.js";
+import { findSeriesByUser } from "$lib/server/repositories/board-series.js";
+import type { RequestHandler } from "./$types";
+
+export const GET: RequestHandler = async (event) => {
+	try {
+		const user = await requireApiV1Auth(event);
+		const series = await findSeriesByUser(user.userId);
+		return json({ success: true, series });
+	} catch (err) {
+		if (err instanceof Response) throw err;
+		return json({ success: false, error: "Failed to fetch series" }, { status: 500 });
+	}
+};

--- a/src/routes/api/v1/series/[id]/agreements/+server.ts
+++ b/src/routes/api/v1/series/[id]/agreements/+server.ts
@@ -1,0 +1,79 @@
+import { json } from "@sveltejs/kit";
+import { and, count, desc, eq } from "drizzle-orm";
+import { requireApiV1Auth } from "$lib/server/auth/index.js";
+import { requireSeriesMember } from "$lib/server/api/v1-access.js";
+import { db } from "$lib/server/db/index.js";
+import { agreements, boardSeries, boards, users } from "$lib/server/db/schema.js";
+import type { RequestHandler } from "./$types";
+
+export const GET: RequestHandler = async (event) => {
+	try {
+		const user = await requireApiV1Auth(event);
+		const seriesId = event.params.id;
+
+		const [series] = await db
+			.select({ id: boardSeries.id })
+			.from(boardSeries)
+			.where(eq(boardSeries.id, seriesId))
+			.limit(1);
+		if (!series) return json({ success: false, error: "Series not found" }, { status: 404 });
+
+		const member = await requireSeriesMember(user.userId, seriesId);
+		if (!member) return json({ success: false, error: "Access denied" }, { status: 403 });
+
+		const url = event.url;
+		const completedParam = url.searchParams.get("completed");
+		const limit = Math.min(Math.max(Number(url.searchParams.get("limit") ?? 50), 1), 200);
+		const offset = Math.max(Number(url.searchParams.get("offset") ?? 0), 0);
+
+		const completedFilter =
+			completedParam === "true" ? true : completedParam === "false" ? false : null;
+
+		// completedBy user join
+		const completedByUser = {
+			id: users.id,
+			name: users.name,
+		};
+
+		const where = and(
+			eq(boards.seriesId, seriesId),
+			completedFilter !== null ? eq(agreements.completed, completedFilter) : undefined,
+		);
+
+		const [rows, [{ total }]] = await Promise.all([
+			db
+				.select({
+					id: agreements.id,
+					content: agreements.content,
+					completed: agreements.completed,
+					boardId: boards.id,
+					boardName: boards.name,
+					meetingDate: boards.meetingDate,
+					createdAt: agreements.createdAt,
+					completedAt: agreements.completedAt,
+					completedByName: users.name,
+				})
+				.from(agreements)
+				.innerJoin(boards, eq(boards.id, agreements.boardId))
+				.leftJoin(users, eq(users.id, agreements.completedByUserId))
+				.where(where)
+				.orderBy(desc(boards.meetingDate), desc(agreements.createdAt))
+				.limit(limit)
+				.offset(offset),
+			db
+				.select({ total: count() })
+				.from(agreements)
+				.innerJoin(boards, eq(boards.id, agreements.boardId))
+				.where(where),
+		]);
+
+		return json({
+			success: true,
+			agreements: rows,
+			meta: { total, limit, offset },
+		});
+	} catch (err) {
+		if (err instanceof Response) throw err;
+		return json({ success: false, error: "Failed to fetch agreements" }, { status: 500 });
+	}
+};

--- a/src/routes/api/v1/series/[id]/boards/+server.ts
+++ b/src/routes/api/v1/series/[id]/boards/+server.ts
@@ -1,0 +1,269 @@
+import { json } from "@sveltejs/kit";
+import { and, count, desc, eq, sql } from "drizzle-orm";
+import { z } from "zod";
+import { requireApiV1Auth } from "$lib/server/auth/index.js";
+import { requireSeriesMember } from "$lib/server/api/v1-access.js";
+import { db } from "$lib/server/db/index.js";
+import {
+	agreements,
+	boardSeries,
+	boards,
+	cards,
+	columns,
+	scenes,
+	sceneFlags,
+} from "$lib/server/db/schema.js";
+import { withTransaction } from "$lib/server/db/transaction.js";
+import { v4 as uuidv4 } from "uuid";
+import type { RequestHandler } from "./$types";
+
+const SCENE_MODES = [
+	"columns",
+	"present",
+	"review",
+	"agreements",
+	"scorecard",
+	"static",
+	"survey",
+	"quadrant",
+] as const;
+
+const createBoardSchema = z.object({
+	name: z.string().min(1).max(100),
+	meetingDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+	blameFreeMode: z.boolean().optional().default(false),
+	votingAllocation: z.number().int().min(0).max(10).optional().default(3),
+	columns: z
+		.array(
+			z.object({
+				title: z.string().min(1).max(100),
+				description: z.string().max(500).optional(),
+				seq: z.number().int().positive().optional(),
+			}),
+		)
+		.max(20)
+		.optional()
+		.default([]),
+	scenes: z
+		.array(
+			z.object({
+				title: z.string().min(1).max(100),
+				mode: z.enum(SCENE_MODES),
+				seq: z.number().int().positive().optional(),
+				flags: z.array(z.string()).optional().default([]),
+				displayRule: z.string().optional(),
+			}),
+		)
+		.max(20)
+		.optional()
+		.default([]),
+	cards: z
+		.array(
+			z.object({
+				columnTitle: z.string(),
+				content: z.string().min(1).max(2000),
+				notes: z.string().max(5000).optional(),
+			}),
+		)
+		.optional()
+		.default([]),
+});
+
+export const GET: RequestHandler = async (event) => {
+	try {
+		const user = await requireApiV1Auth(event);
+		const seriesId = event.params.id;
+
+		const [series] = await db
+			.select({ id: boardSeries.id })
+			.from(boardSeries)
+			.where(eq(boardSeries.id, seriesId))
+			.limit(1);
+		if (!series) return json({ success: false, error: "Series not found" }, { status: 404 });
+
+		const member = await requireSeriesMember(user.userId, seriesId);
+		if (!member) return json({ success: false, error: "Access denied" }, { status: 403 });
+
+		const url = event.url;
+		const statusFilter = url.searchParams.get("status") ?? null;
+		const limit = Math.min(Math.max(Number(url.searchParams.get("limit") ?? 20), 1), 100);
+		const offset = Math.max(Number(url.searchParams.get("offset") ?? 0), 0);
+
+		const where = and(
+			eq(boards.seriesId, seriesId),
+			statusFilter ? eq(boards.status, statusFilter as any) : undefined,
+		);
+
+		const [boardRows, [{ total }]] = await Promise.all([
+			db
+				.select({
+					id: boards.id,
+					name: boards.name,
+					status: boards.status,
+					meetingDate: boards.meetingDate,
+					createdAt: boards.createdAt,
+					sceneCount: sql<number>`(SELECT COUNT(*) FROM scenes WHERE scenes.board_id = ${boards.id})`,
+					cardCount: sql<number>`(SELECT COUNT(*) FROM cards c JOIN columns col ON c.column_id = col.id WHERE col.board_id = ${boards.id})`,
+					agreementCount: sql<number>`(SELECT COUNT(*) FROM agreements WHERE agreements.board_id = ${boards.id})`,
+				})
+				.from(boards)
+				.where(where)
+				.orderBy(desc(boards.meetingDate), desc(boards.createdAt))
+				.limit(limit)
+				.offset(offset),
+			db
+				.select({ total: count() })
+				.from(boards)
+				.where(where),
+		]);
+
+		return json({
+			success: true,
+			boards: boardRows,
+			meta: { total, limit, offset },
+		});
+	} catch (err) {
+		if (err instanceof Response) throw err;
+		return json({ success: false, error: "Failed to fetch boards" }, { status: 500 });
+	}
+};
+
+export const POST: RequestHandler = async (event) => {
+	try {
+		const user = await requireApiV1Auth(event);
+		const seriesId = event.params.id;
+
+		const [series] = await db
+			.select({ id: boardSeries.id })
+			.from(boardSeries)
+			.where(eq(boardSeries.id, seriesId))
+			.limit(1);
+		if (!series) return json({ success: false, error: "Series not found" }, { status: 404 });
+
+		const member = await requireSeriesMember(user.userId, seriesId);
+		if (!member) return json({ success: false, error: "Access denied" }, { status: 403 });
+
+		const body = await event.request.json();
+		const data = createBoardSchema.parse(body);
+
+		// Validate card column references before touching the DB
+		if (data.cards.length > 0) {
+			const columnTitles = new Set(data.columns.map((c) => c.title));
+			for (const card of data.cards) {
+				if (!columnTitles.has(card.columnTitle)) {
+					return json(
+						{
+							success: false,
+							error: `Card references unknown column: '${card.columnTitle}'`,
+						},
+						{ status: 400 },
+					);
+				}
+			}
+		}
+
+		const now = new Date().toISOString();
+		const boardId = uuidv4();
+
+		const result = await withTransaction(async (tx) => {
+			// Create board
+			await tx.insert(boards).values({
+				id: boardId,
+				seriesId,
+				name: data.name,
+				status: "draft",
+				blameFreeMode: data.blameFreeMode,
+				votingAllocation: data.votingAllocation,
+				meetingDate: data.meetingDate ?? null,
+				createdAt: now,
+				updatedAt: now,
+			});
+
+			// Create columns
+			const columnMap = new Map<string, string>(); // title → id
+			const createdColumns = [];
+			for (let i = 0; i < data.columns.length; i++) {
+				const col = data.columns[i];
+				const colId = uuidv4();
+				const seq = col.seq ?? i + 1;
+				await tx.insert(columns).values({
+					id: colId,
+					boardId,
+					title: col.title,
+					description: col.description ?? null,
+					seq,
+					createdAt: now,
+				});
+				columnMap.set(col.title, colId);
+				createdColumns.push({ id: colId, title: col.title, seq });
+			}
+
+			// Create scenes
+			const createdScenes = [];
+			for (let i = 0; i < data.scenes.length; i++) {
+				const scene = data.scenes[i];
+				const sceneId = uuidv4();
+				const seq = scene.seq ?? i + 1;
+				await tx.insert(scenes).values({
+					id: sceneId,
+					boardId,
+					title: scene.title,
+					mode: scene.mode,
+					seq,
+					displayRule: scene.displayRule ?? null,
+					createdAt: now,
+				});
+				// Insert scene flags
+				for (const flag of scene.flags) {
+					await tx.insert(sceneFlags).values({ sceneId, flag });
+				}
+				createdScenes.push({ id: sceneId, title: scene.title, mode: scene.mode, seq, flags: scene.flags });
+			}
+
+			// Create seed cards
+			const createdCards = [];
+			for (let i = 0; i < data.cards.length; i++) {
+				const card = data.cards[i];
+				const cardId = uuidv4();
+				const colId = columnMap.get(card.columnTitle)!;
+				await tx.insert(cards).values({
+					id: cardId,
+					columnId: colId,
+					userId: user.userId,
+					content: card.content,
+					notes: card.notes ?? null,
+					seq: i + 1,
+					createdAt: now,
+					updatedAt: now,
+				});
+				createdCards.push({ id: cardId, columnId: colId, content: card.content });
+			}
+
+			return { columns: createdColumns, scenes: createdScenes, cards: createdCards };
+		});
+
+		return json(
+			{
+				success: true,
+				board: {
+					id: boardId,
+					name: data.name,
+					status: "draft",
+					meetingDate: data.meetingDate ?? null,
+					columns: result.columns,
+					scenes: result.scenes,
+					cards: result.cards,
+					createdAt: now,
+				},
+			},
+			{ status: 201 },
+		);
+	} catch (err) {
+		if (err instanceof Response) throw err;
+		if (err instanceof z.ZodError) {
+			return json({ success: false, error: "Invalid input", details: err.errors }, { status: 400 });
+		}
+		console.error("[v1 POST /series/:id/boards]", err);
+		return json({ success: false, error: "Failed to create board" }, { status: 500 });
+	}
+};

--- a/src/routes/api/v1/series/[id]/health-summary/+server.ts
+++ b/src/routes/api/v1/series/[id]/health-summary/+server.ts
@@ -1,0 +1,137 @@
+import { json } from "@sveltejs/kit";
+import { asc, desc, eq } from "drizzle-orm";
+import { requireApiV1Auth } from "$lib/server/auth/index.js";
+import { requireSeriesMember } from "$lib/server/api/v1-access.js";
+import { db } from "$lib/server/db/index.js";
+import {
+	boardSeries,
+	boards,
+	healthQuestions,
+	healthResponses,
+	scenes,
+} from "$lib/server/db/schema.js";
+import type { RequestHandler } from "./$types";
+
+export const GET: RequestHandler = async (event) => {
+	try {
+		const user = await requireApiV1Auth(event);
+		const seriesId = event.params.id;
+
+		const [series] = await db
+			.select({ id: boardSeries.id, name: boardSeries.name })
+			.from(boardSeries)
+			.where(eq(boardSeries.id, seriesId))
+			.limit(1);
+		if (!series) return json({ success: false, error: "Series not found" }, { status: 404 });
+
+		const member = await requireSeriesMember(user.userId, seriesId);
+		if (!member) return json({ success: false, error: "Access denied" }, { status: 403 });
+
+		const boardLimit = Math.min(
+			Math.max(Number(event.url.searchParams.get("limit") ?? 10), 1),
+			50,
+		);
+
+		// Get recent boards (sorted newest-first for slicing, then reversed for history order)
+		const recentBoards = await db
+			.select({ id: boards.id, name: boards.name, meetingDate: boards.meetingDate })
+			.from(boards)
+			.where(eq(boards.seriesId, seriesId))
+			.orderBy(desc(boards.meetingDate), desc(boards.createdAt))
+			.limit(boardLimit);
+
+		if (recentBoards.length === 0) {
+			return json({ success: true, series, questions: [] });
+		}
+
+		const boardIndex = new Map(recentBoards.map((b) => [b.id, b]));
+
+		// One query: health questions → scenes → boards → responses for this series
+		const allQuestionRows = await db
+			.select({
+				threadId: healthQuestions.threadId,
+				question: healthQuestions.question,
+				questionType: healthQuestions.questionType,
+				boardId: boards.id,
+				boardName: boards.name,
+				meetingDate: boards.meetingDate,
+				rating: healthResponses.rating,
+			})
+			.from(healthQuestions)
+			.innerJoin(scenes, eq(scenes.id, healthQuestions.sceneId))
+			.innerJoin(boards, eq(boards.id, scenes.boardId))
+			.leftJoin(healthResponses, eq(healthResponses.questionId, healthQuestions.id))
+			.where(eq(boards.seriesId, seriesId))
+			.orderBy(asc(boards.meetingDate), asc(healthQuestions.seq));
+
+		// Aggregate: threadId → { question meta, boardData map }
+		const threadMap = new Map<
+			string,
+			{
+				threadId: string;
+				question: string;
+				questionType: string;
+				boardData: Map<string, { boardId: string; boardName: string; meetingDate: string | null; ratings: number[] }>;
+			}
+		>();
+
+		for (const row of allQuestionRows) {
+			if (!boardIndex.has(row.boardId)) continue;
+
+			if (!threadMap.has(row.threadId)) {
+				threadMap.set(row.threadId, {
+					threadId: row.threadId,
+					question: row.question,
+					questionType: row.questionType,
+					boardData: new Map(),
+				});
+			}
+			const thread = threadMap.get(row.threadId)!;
+
+			if (!thread.boardData.has(row.boardId)) {
+				thread.boardData.set(row.boardId, {
+					boardId: row.boardId,
+					boardName: row.boardName,
+					meetingDate: row.meetingDate,
+					ratings: [],
+				});
+			}
+
+			if (row.rating !== null) {
+				thread.boardData.get(row.boardId)!.ratings.push(row.rating);
+			}
+		}
+
+		const questions = Array.from(threadMap.values()).map((thread) => {
+			const history = Array.from(thread.boardData.values())
+				.sort((a, b) => {
+					if (!a.meetingDate && !b.meetingDate) return 0;
+					if (!a.meetingDate) return 1;
+					if (!b.meetingDate) return -1;
+					return a.meetingDate.localeCompare(b.meetingDate);
+				})
+				.map((bd) => {
+					const { ratings } = bd;
+					const responseCount = ratings.length;
+					const avgRating =
+						responseCount > 0
+							? Math.round((ratings.reduce((a, b) => a + b, 0) / responseCount) * 10) / 10
+							: null;
+					const distribution: Record<string, number> = {};
+					for (const r of ratings) {
+						const key = String(r);
+						distribution[key] = (distribution[key] ?? 0) + 1;
+					}
+					return { boardId: bd.boardId, boardName: bd.boardName, meetingDate: bd.meetingDate, avgRating, responseCount, distribution };
+				});
+
+			return { threadId: thread.threadId, question: thread.question, questionType: thread.questionType, history };
+		});
+
+		return json({ success: true, series, questions });
+	} catch (err) {
+		if (err instanceof Response) throw err;
+		console.error("[v1 health-summary]", err);
+		return json({ success: false, error: "Failed to fetch health summary" }, { status: 500 });
+	}
+};

--- a/src/routes/api/v1/tokens/+server.ts
+++ b/src/routes/api/v1/tokens/+server.ts
@@ -1,0 +1,47 @@
+import { json } from "@sveltejs/kit";
+import { z } from "zod";
+import { requireApiV1Auth } from "$lib/server/auth/index.js";
+import {
+	createApiToken,
+	listApiTokens,
+	revokeApiToken,
+} from "$lib/server/repositories/api-tokens.js";
+import type { RequestHandler } from "./$types";
+
+const createSchema = z.object({
+	label: z.string().min(1, "label is required").max(100),
+});
+
+export const GET: RequestHandler = async (event) => {
+	try {
+		const user = await requireApiV1Auth(event);
+		const tokens = await listApiTokens(user.userId);
+		return json({ success: true, tokens });
+	} catch (err) {
+		if (err instanceof Response) throw err;
+		return json({ success: false, error: "Failed to list tokens" }, { status: 500 });
+	}
+};
+
+export const POST: RequestHandler = async (event) => {
+	try {
+		const user = await requireApiV1Auth(event);
+		const body = await event.request.json();
+		const { label } = createSchema.parse(body);
+
+		const result = await createApiToken(user.userId, label);
+		return json(
+			{ success: true, token: result.rawToken, tokenInfo: result.tokenInfo },
+			{ status: 201 },
+		);
+	} catch (err) {
+		if (err instanceof Response) throw err;
+		if (err instanceof z.ZodError) {
+			return json(
+				{ success: false, error: "Invalid input", details: err.errors },
+				{ status: 400 },
+			);
+		}
+		return json({ success: false, error: "Failed to create token" }, { status: 500 });
+	}
+};

--- a/src/routes/api/v1/tokens/[id]/+server.ts
+++ b/src/routes/api/v1/tokens/[id]/+server.ts
@@ -1,0 +1,18 @@
+import { json } from "@sveltejs/kit";
+import { requireApiV1Auth } from "$lib/server/auth/index.js";
+import { revokeApiToken } from "$lib/server/repositories/api-tokens.js";
+import type { RequestHandler } from "./$types";
+
+export const DELETE: RequestHandler = async (event) => {
+	try {
+		const user = await requireApiV1Auth(event);
+		const revoked = await revokeApiToken(event.params.id, user.userId);
+		if (!revoked) {
+			return json({ success: false, error: "Token not found" }, { status: 404 });
+		}
+		return json({ success: true });
+	} catch (err) {
+		if (err instanceof Response) throw err;
+		return json({ success: false, error: "Failed to revoke token" }, { status: 500 });
+	}
+};

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { onMount } from "svelte";
+import ApiTokenManager from "$lib/components/ApiTokenManager.svelte";
 import PasskeyManager from "$lib/components/PasskeyManager.svelte";
 import Icon from "$lib/components/ui/Icon.svelte";
 
@@ -303,6 +304,11 @@ async function resendVerificationEmail() {
                 <!-- Passkey Manager -->
                 <PasskeyManager />
 
+                <!-- API Tokens -->
+                <section class="profile-section api-tokens-section">
+                    <ApiTokenManager />
+                </section>
+
                 <!-- Delete Account -->
                 <section class="profile-section danger-section">
                     <h2 class="section-title section-title-danger">
@@ -416,6 +422,10 @@ async function resendVerificationEmail() {
     .danger-section {
         grid-column: 1 / -1;
         border: 1px solid var(--color-danger);
+    }
+
+    .api-tokens-section {
+        grid-column: 1 / -1;
     }
 
     .section-title {

--- a/tests/unit/api/v1/boards.test.ts
+++ b/tests/unit/api/v1/boards.test.ts
@@ -1,0 +1,255 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../../src/lib/server/auth/index", () => ({
+	requireApiV1Auth: vi.fn(),
+}));
+
+vi.mock("../../../../src/lib/server/api/v1-access", () => ({
+	getBoardSeriesForUser: vi.fn(),
+	requireSeriesMember: vi.fn(),
+}));
+
+vi.mock("../../../../src/lib/server/db/index", () => ({
+	db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn() },
+}));
+
+vi.mock("../../../../src/lib/server/db/schema", () => ({
+	boards: {},
+	columns: {},
+	scenes: {},
+	sceneFlags: {},
+	cards: {},
+	agreements: {},
+	users: {},
+	scorecardDatasources: {},
+	scorecards: {},
+	sceneScorecards: {},
+	sceneScorecardResults: {},
+}));
+
+vi.mock("../../../../src/lib/server/db/transaction", () => ({
+	withTransaction: vi.fn((fn: any) => fn({ insert: vi.fn().mockResolvedValue(undefined) })),
+}));
+
+vi.mock("uuid", () => ({ v4: vi.fn(() => "mock-uuid") }));
+
+import { requireApiV1Auth } from "../../../../src/lib/server/auth/index";
+import { getBoardSeriesForUser } from "../../../../src/lib/server/api/v1-access";
+import { db } from "../../../../src/lib/server/db/index";
+import { GET as getBoardDetail } from "../../../../src/routes/api/v1/boards/[id]/+server";
+import { GET as getBoardCards } from "../../../../src/routes/api/v1/boards/[id]/cards/+server";
+import { GET as getBoardAgreements } from "../../../../src/routes/api/v1/boards/[id]/agreements/+server";
+import { createMockRequestEvent } from "../../helpers/mock-request";
+
+const mockUser = { userId: "user-1", email: "test@example.com", expiresAt: 0 };
+
+// ─────────────────────────────────────────────────────────────────────
+// GET /api/v1/boards/:id
+// ─────────────────────────────────────────────────────────────────────
+
+describe("GET /api/v1/boards/:id", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("returns 401 when not authenticated", async () => {
+		vi.mocked(requireApiV1Auth).mockRejectedValue(
+			new Response(JSON.stringify({ success: false, error: "Unauthorized" }), { status: 401 }),
+		);
+		const event = createMockRequestEvent({
+			url: "http://localhost/api/v1/boards/board-1",
+			params: { id: "board-1" },
+		});
+		await expect(getBoardDetail(event)).rejects.toBeInstanceOf(Response);
+	});
+
+	it("returns 404 when board does not exist", async () => {
+		vi.mocked(requireApiV1Auth).mockResolvedValue(mockUser);
+		vi.mocked(getBoardSeriesForUser).mockResolvedValue("not_found");
+
+		const event = createMockRequestEvent({
+			url: "http://localhost/api/v1/boards/nonexistent",
+			params: { id: "nonexistent" },
+		});
+
+		const response = await getBoardDetail(event);
+		const data = await response.json();
+
+		expect(response.status).toBe(404);
+		expect(data.error).toBe("Board not found");
+	});
+
+	it("returns 403 when user is not a series member", async () => {
+		vi.mocked(requireApiV1Auth).mockResolvedValue(mockUser);
+		vi.mocked(getBoardSeriesForUser).mockResolvedValue("forbidden");
+
+		const event = createMockRequestEvent({
+			url: "http://localhost/api/v1/boards/board-1",
+			params: { id: "board-1" },
+		});
+
+		const response = await getBoardDetail(event);
+		const data = await response.json();
+
+		expect(response.status).toBe(403);
+		expect(data.error).toBe("Access denied");
+	});
+
+	it("returns board detail when authorized", async () => {
+		vi.mocked(requireApiV1Auth).mockResolvedValue(mockUser);
+		vi.mocked(getBoardSeriesForUser).mockResolvedValue({ seriesId: "series-1" });
+
+		const mockBoard = {
+			id: "board-1",
+			seriesId: "series-1",
+			name: "Sprint 42",
+			status: "completed",
+			meetingDate: "2026-06-01",
+			blameFreeMode: false,
+			votingAllocation: 3,
+			votingEnabled: true,
+			currentSceneId: null,
+			createdAt: "2026-05-30T10:00:00Z",
+		};
+
+		// db.select returns different shapes depending on what's being queried.
+		// We mock it to return board, columns, scenes, cards in sequence via Promise.all.
+		// The component calls Promise.all([[board], columns, scenes, cards]).
+		let callCount = 0;
+		vi.mocked(db.select).mockImplementation(() => {
+			callCount++;
+			const limit1 = vi.fn().mockResolvedValue([mockBoard]);
+			const orderBy = vi.fn().mockResolvedValue([]);
+			const where = vi.fn().mockReturnValue({ limit: limit1, orderBy });
+			const innerJoin = vi.fn().mockReturnValue({ where });
+			return { from: vi.fn().mockReturnValue({ where, innerJoin, orderBy }) } as any;
+		});
+
+		const event = createMockRequestEvent({
+			url: "http://localhost/api/v1/boards/board-1",
+			params: { id: "board-1" },
+		});
+
+		const response = await getBoardDetail(event);
+		const data = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(data.success).toBe(true);
+		expect(data.board).toBeDefined();
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// GET /api/v1/boards/:id/cards
+// ─────────────────────────────────────────────────────────────────────
+
+describe("GET /api/v1/boards/:id/cards", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("returns 403 when user is not a member", async () => {
+		vi.mocked(requireApiV1Auth).mockResolvedValue(mockUser);
+		vi.mocked(getBoardSeriesForUser).mockResolvedValue("forbidden");
+
+		const event = createMockRequestEvent({
+			url: "http://localhost/api/v1/boards/board-1/cards",
+			params: { id: "board-1" },
+		});
+
+		const response = await getBoardCards(event);
+		expect(response.status).toBe(403);
+	});
+
+	it("returns card list when authorized", async () => {
+		vi.mocked(requireApiV1Auth).mockResolvedValue(mockUser);
+		vi.mocked(getBoardSeriesForUser).mockResolvedValue({ seriesId: "series-1" });
+
+		const mockCards = [
+			{ id: "card-1", columnId: "col-1", columnTitle: "Went well", content: "Shipped on time", voteCount: 3, commentCount: 1, groupId: null, isGroupLead: false, seq: 1, createdAt: "2026-06-01T00:00:00Z" },
+		];
+
+		const mockOrderBy = vi.fn().mockResolvedValue(mockCards);
+		const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
+		const mockInnerJoin = vi.fn().mockReturnValue({ where: mockWhere });
+		const mockFrom = vi.fn().mockReturnValue({ innerJoin: mockInnerJoin });
+		vi.mocked(db.select).mockReturnValue({ from: mockFrom } as any);
+
+		const event = createMockRequestEvent({
+			url: "http://localhost/api/v1/boards/board-1/cards",
+			params: { id: "board-1" },
+		});
+
+		const response = await getBoardCards(event);
+		const data = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(data.success).toBe(true);
+		expect(data.cards).toEqual(mockCards);
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// GET /api/v1/boards/:id/agreements
+// ─────────────────────────────────────────────────────────────────────
+
+describe("GET /api/v1/boards/:id/agreements", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("returns 404 when board not found", async () => {
+		vi.mocked(requireApiV1Auth).mockResolvedValue(mockUser);
+		vi.mocked(getBoardSeriesForUser).mockResolvedValue("not_found");
+
+		const event = createMockRequestEvent({
+			url: "http://localhost/api/v1/boards/bad/agreements",
+			params: { id: "bad" },
+		});
+
+		const response = await getBoardAgreements(event);
+		expect(response.status).toBe(404);
+	});
+
+	it("returns agreements list when authorized", async () => {
+		vi.mocked(requireApiV1Auth).mockResolvedValue(mockUser);
+		vi.mocked(getBoardSeriesForUser).mockResolvedValue({ seriesId: "series-1" });
+
+		const mockAgreements = [
+			{ id: "ag-1", content: "Write more tests", completed: false, createdAt: "2026-06-01T00:00:00Z", completedAt: null, completedByName: null },
+		];
+
+		const mockOrderBy = vi.fn().mockResolvedValue(mockAgreements);
+		const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
+		const mockLeftJoin = vi.fn().mockReturnValue({ where: mockWhere });
+		const mockFrom = vi.fn().mockReturnValue({ leftJoin: mockLeftJoin });
+		vi.mocked(db.select).mockReturnValue({ from: mockFrom } as any);
+
+		const event = createMockRequestEvent({
+			url: "http://localhost/api/v1/boards/board-1/agreements",
+			params: { id: "board-1" },
+		});
+
+		const response = await getBoardAgreements(event);
+		const data = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(data.success).toBe(true);
+		expect(data.agreements).toEqual(mockAgreements);
+	});
+
+	it("filters by completed=true when query param is set", async () => {
+		vi.mocked(requireApiV1Auth).mockResolvedValue(mockUser);
+		vi.mocked(getBoardSeriesForUser).mockResolvedValue({ seriesId: "series-1" });
+
+		const mockOrderBy = vi.fn().mockResolvedValue([]);
+		const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
+		const mockLeftJoin = vi.fn().mockReturnValue({ where: mockWhere });
+		const mockFrom = vi.fn().mockReturnValue({ leftJoin: mockLeftJoin });
+		vi.mocked(db.select).mockReturnValue({ from: mockFrom } as any);
+
+		const event = createMockRequestEvent({
+			url: "http://localhost/api/v1/boards/board-1/agreements?completed=true",
+			params: { id: "board-1" },
+		});
+
+		const response = await getBoardAgreements(event);
+		expect(response.status).toBe(200);
+		// The where clause should have been called with a completed filter
+		expect(mockWhere).toHaveBeenCalled();
+	});
+});

--- a/tests/unit/api/v1/series.test.ts
+++ b/tests/unit/api/v1/series.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../../src/lib/server/auth/index", () => ({
+	requireApiV1Auth: vi.fn(),
+}));
+
+vi.mock("../../../../src/lib/server/repositories/board-series", () => ({
+	findSeriesByUser: vi.fn(),
+}));
+
+vi.mock("../../../../src/lib/server/api/v1-access", () => ({
+	requireSeriesMember: vi.fn(),
+}));
+
+vi.mock("../../../../src/lib/server/db/index", () => ({
+	db: { select: vi.fn(), insert: vi.fn() },
+}));
+
+vi.mock("../../../../src/lib/server/db/schema", () => ({
+	boardSeries: {},
+	boards: {},
+	columns: {},
+	scenes: {},
+	sceneFlags: {},
+	cards: {},
+	agreements: {},
+}));
+
+vi.mock("../../../../src/lib/server/db/transaction", () => ({
+	withTransaction: vi.fn((fn: any) => fn({ insert: vi.fn().mockResolvedValue(undefined) })),
+}));
+
+import { requireApiV1Auth } from "../../../../src/lib/server/auth/index";
+import { findSeriesByUser } from "../../../../src/lib/server/repositories/board-series";
+import { GET } from "../../../../src/routes/api/v1/series/+server";
+import { createMockRequestEvent } from "../../helpers/mock-request";
+
+const mockUser = { userId: "user-1", email: "test@example.com", expiresAt: 0 };
+
+describe("GET /api/v1/series", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("returns 401 when not authenticated", async () => {
+		vi.mocked(requireApiV1Auth).mockRejectedValue(
+			new Response(JSON.stringify({ success: false, error: "Unauthorized" }), { status: 401 }),
+		);
+		const event = createMockRequestEvent({ url: "http://localhost/api/v1/series" });
+		await expect(GET(event)).rejects.toBeInstanceOf(Response);
+	});
+
+	it("returns series for authenticated user", async () => {
+		vi.mocked(requireApiV1Auth).mockResolvedValue(mockUser);
+		const mockSeries = [
+			{
+				id: "series-1",
+				name: "Eng Retros",
+				slug: "eng-retros",
+				description: null,
+				role: "admin",
+				createdAt: "2026-01-01T00:00:00Z",
+			},
+		];
+		vi.mocked(findSeriesByUser).mockResolvedValue(mockSeries as any);
+
+		const event = createMockRequestEvent({ url: "http://localhost/api/v1/series" });
+		const response = await GET(event);
+		const data = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(data.success).toBe(true);
+		expect(data.series).toEqual(mockSeries);
+		expect(findSeriesByUser).toHaveBeenCalledWith("user-1");
+	});
+
+	it("accepts Bearer token in Authorization header", async () => {
+		// requireApiV1Auth already handles this; just verify it's called with the event
+		vi.mocked(requireApiV1Auth).mockResolvedValue(mockUser);
+		vi.mocked(findSeriesByUser).mockResolvedValue([]);
+
+		const event = createMockRequestEvent({
+			url: "http://localhost/api/v1/series",
+			headers: { Authorization: "Bearer tb_abc123" },
+		});
+
+		const response = await GET(event);
+		expect(response.status).toBe(200);
+		expect(requireApiV1Auth).toHaveBeenCalledWith(event);
+	});
+});

--- a/tests/unit/api/v1/tokens.test.ts
+++ b/tests/unit/api/v1/tokens.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../../src/lib/server/auth/index", () => ({
+	requireApiV1Auth: vi.fn(),
+}));
+
+vi.mock("../../../../src/lib/server/repositories/api-tokens", () => ({
+	createApiToken: vi.fn(),
+	listApiTokens: vi.fn(),
+	revokeApiToken: vi.fn(),
+}));
+
+import { requireApiV1Auth } from "../../../../src/lib/server/auth/index";
+import {
+	createApiToken,
+	listApiTokens,
+	revokeApiToken,
+} from "../../../../src/lib/server/repositories/api-tokens";
+import { GET, POST } from "../../../../src/routes/api/v1/tokens/+server";
+import { DELETE } from "../../../../src/routes/api/v1/tokens/[id]/+server";
+import { createMockRequestEvent } from "../../helpers/mock-request";
+
+const mockUser = { userId: "user-1", email: "test@example.com", expiresAt: 0 };
+
+describe("GET /api/v1/tokens", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("returns 401 when not authenticated", async () => {
+		vi.mocked(requireApiV1Auth).mockRejectedValue(
+			new Response(JSON.stringify({ success: false, error: "Unauthorized" }), { status: 401 }),
+		);
+
+		const event = createMockRequestEvent({ url: "http://localhost/api/v1/tokens" });
+
+		await expect(GET(event)).rejects.toBeInstanceOf(Response);
+	});
+
+	it("returns token list for authenticated user", async () => {
+		vi.mocked(requireApiV1Auth).mockResolvedValue(mockUser);
+		const mockTokens = [{ id: "tok-1", label: "Agent", expiresAt: Date.now() + 1000000, lastUsedAt: null, createdAt: Date.now() }];
+		vi.mocked(listApiTokens).mockResolvedValue(mockTokens as any);
+
+		const event = createMockRequestEvent({ url: "http://localhost/api/v1/tokens" });
+		const response = await GET(event);
+		const data = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(data.success).toBe(true);
+		expect(data.tokens).toEqual(mockTokens);
+		expect(listApiTokens).toHaveBeenCalledWith("user-1");
+	});
+});
+
+describe("POST /api/v1/tokens", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("returns 201 with raw token on success", async () => {
+		vi.mocked(requireApiV1Auth).mockResolvedValue(mockUser);
+		vi.mocked(createApiToken).mockResolvedValue({
+			rawToken: "tb_abc123",
+			tokenInfo: { id: "tok-1", label: "My agent", expiresAt: Date.now() + 1000000, lastUsedAt: null, createdAt: Date.now() },
+		} as any);
+
+		const event = createMockRequestEvent({
+			method: "POST",
+			url: "http://localhost/api/v1/tokens",
+			body: { label: "My agent" },
+		});
+
+		const response = await POST(event);
+		const data = await response.json();
+
+		expect(response.status).toBe(201);
+		expect(data.success).toBe(true);
+		expect(data.token).toBe("tb_abc123");
+		expect(data.tokenInfo.label).toBe("My agent");
+		expect(createApiToken).toHaveBeenCalledWith("user-1", "My agent");
+	});
+
+	it("returns 400 when label is empty", async () => {
+		vi.mocked(requireApiV1Auth).mockResolvedValue(mockUser);
+
+		const event = createMockRequestEvent({
+			method: "POST",
+			url: "http://localhost/api/v1/tokens",
+			body: { label: "" },
+		});
+
+		const response = await POST(event);
+		const data = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(data.success).toBe(false);
+		expect(data.error).toBe("Invalid input");
+		expect(createApiToken).not.toHaveBeenCalled();
+	});
+
+	it("returns 400 when label exceeds 100 chars", async () => {
+		vi.mocked(requireApiV1Auth).mockResolvedValue(mockUser);
+
+		const event = createMockRequestEvent({
+			method: "POST",
+			url: "http://localhost/api/v1/tokens",
+			body: { label: "x".repeat(101) },
+		});
+
+		const response = await POST(event);
+		const data = await response.json();
+		expect(response.status).toBe(400);
+		expect(data.success).toBe(false);
+		expect(data.error).toBe("Invalid input");
+	});
+});
+
+describe("DELETE /api/v1/tokens/:id", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("returns 200 when token is successfully revoked", async () => {
+		vi.mocked(requireApiV1Auth).mockResolvedValue(mockUser);
+		vi.mocked(revokeApiToken).mockResolvedValue(true);
+
+		const event = createMockRequestEvent({
+			method: "DELETE",
+			url: "http://localhost/api/v1/tokens/tok-1",
+			params: { id: "tok-1" },
+		});
+
+		const response = await DELETE(event);
+		const data = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(data.success).toBe(true);
+		expect(revokeApiToken).toHaveBeenCalledWith("tok-1", "user-1");
+	});
+
+	it("returns 404 when token does not exist or belongs to another user", async () => {
+		vi.mocked(requireApiV1Auth).mockResolvedValue(mockUser);
+		vi.mocked(revokeApiToken).mockResolvedValue(false);
+
+		const event = createMockRequestEvent({
+			method: "DELETE",
+			url: "http://localhost/api/v1/tokens/unknown",
+			params: { id: "unknown" },
+		});
+
+		const response = await DELETE(event);
+		const data = await response.json();
+
+		expect(response.status).toBe(404);
+		expect(data.success).toBe(false);
+	});
+});

--- a/tests/unit/auth/api-token.test.ts
+++ b/tests/unit/auth/api-token.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks must be declared before any imports that trigger them ---
+
+vi.mock("../../../src/lib/server/db/index", () => ({
+	db: {
+		select: vi.fn(),
+		update: vi.fn(),
+	},
+}));
+
+vi.mock("../../../src/lib/server/db/schema", () => ({
+	apiTokens: { id: "id", tokenHash: "token_hash", userId: "user_id", expiresAt: "expires_at" },
+	users: { id: "id", email: "email" },
+}));
+
+import { db } from "../../../src/lib/server/db/index";
+import { generateToken, hashToken, TOKEN_PREFIX, TOKEN_TTL_MS, validateApiToken } from "../../../src/lib/server/auth/api-token";
+
+describe("generateToken", () => {
+	it("produces a token with the tb_ prefix", () => {
+		const { token } = generateToken();
+		expect(token).toMatch(/^tb_[0-9a-f]{64}$/);
+	});
+
+	it("produces a different token on each call", () => {
+		const { token: a } = generateToken();
+		const { token: b } = generateToken();
+		expect(a).not.toBe(b);
+	});
+
+	it("returns a hash alongside the raw token", () => {
+		const { token, hash } = generateToken();
+		expect(hash).toHaveLength(64); // SHA-256 hex
+		expect(hash).not.toBe(token);
+	});
+
+	it("hash is deterministic for the same token", () => {
+		const { token } = generateToken();
+		expect(hashToken(token)).toBe(hashToken(token));
+	});
+});
+
+describe("hashToken", () => {
+	it("returns a 64-char hex string", () => {
+		expect(hashToken("tb_abc")).toMatch(/^[0-9a-f]{64}$/);
+	});
+
+	it("produces different hashes for different inputs", () => {
+		expect(hashToken("tb_aaa")).not.toBe(hashToken("tb_bbb"));
+	});
+});
+
+describe("validateApiToken", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("returns null immediately for tokens without tb_ prefix", async () => {
+		const result = await validateApiToken("some-other-token");
+		expect(result).toBeNull();
+		expect(db.select).not.toHaveBeenCalled();
+	});
+
+	it("returns null when no matching token record found", async () => {
+		const mockLimit = vi.fn().mockResolvedValue([]);
+		const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+		const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+		const mockInnerJoin = vi.fn().mockReturnValue({ where: mockWhere });
+		vi.mocked(db.select).mockReturnValue({ from: mockFrom } as any);
+		mockFrom.mockReturnValue({ innerJoin: mockInnerJoin });
+		mockInnerJoin.mockReturnValue({ where: mockWhere });
+
+		const result = await validateApiToken("tb_" + "a".repeat(64));
+		expect(result).toBeNull();
+	});
+
+	it("returns user data when a valid token is found", async () => {
+		const mockRecord = { tokenId: "tok-1", userId: "user-1", userEmail: "test@example.com" };
+
+		const mockLimit = vi.fn().mockResolvedValue([mockRecord]);
+		const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+		const mockInnerJoin = vi.fn().mockReturnValue({ where: mockWhere });
+		const mockFrom = vi.fn().mockReturnValue({ innerJoin: mockInnerJoin });
+		vi.mocked(db.select).mockReturnValue({ from: mockFrom } as any);
+
+		// Mock update chain (fire-and-forget last-used update)
+		const mockUpdateWhere = vi.fn().mockResolvedValue(undefined);
+		const mockSet = vi.fn().mockReturnValue({ where: mockUpdateWhere });
+		vi.mocked(db.update).mockReturnValue({ set: mockSet } as any);
+
+		const { token } = generateToken();
+		const result = await validateApiToken(token);
+
+		expect(result).toEqual({ userId: "user-1", email: "test@example.com" });
+	});
+
+	it("fires a last-used update after successful validation", async () => {
+		const mockRecord = { tokenId: "tok-1", userId: "user-1", userEmail: "test@example.com" };
+
+		const mockLimit = vi.fn().mockResolvedValue([mockRecord]);
+		const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+		const mockInnerJoin = vi.fn().mockReturnValue({ where: mockWhere });
+		const mockFrom = vi.fn().mockReturnValue({ innerJoin: mockInnerJoin });
+		vi.mocked(db.select).mockReturnValue({ from: mockFrom } as any);
+
+		const mockUpdateWhere = vi.fn().mockResolvedValue(undefined);
+		const mockSet = vi.fn().mockReturnValue({ where: mockUpdateWhere });
+		vi.mocked(db.update).mockReturnValue({ set: mockSet } as any);
+
+		const { token } = generateToken();
+		await validateApiToken(token);
+
+		// Allow the fire-and-forget update to settle
+		await new Promise((r) => setTimeout(r, 10));
+		expect(db.update).toHaveBeenCalled();
+	});
+});

--- a/tests/unit/helpers/mock-request.ts
+++ b/tests/unit/helpers/mock-request.ts
@@ -11,6 +11,7 @@ export function createMockRequestEvent(options: {
 	body?: unknown;
 	locals?: Record<string, unknown>;
 	cookies?: Map<string, string>;
+	headers?: Record<string, string>;
 }): RequestEvent {
 	const {
 		method = "GET",
@@ -19,13 +20,18 @@ export function createMockRequestEvent(options: {
 		body = null,
 		locals = {},
 		cookies = new Map(),
+		headers = {},
 	} = options;
 
 	const requestInit: RequestInit = { method };
 
+	const allHeaders: Record<string, string> = { ...headers };
 	if (body) {
 		requestInit.body = JSON.stringify(body);
-		requestInit.headers = { "Content-Type": "application/json" };
+		allHeaders["Content-Type"] = "application/json";
+	}
+	if (Object.keys(allHeaders).length > 0) {
+		requestInit.headers = allHeaders;
 	}
 
 	const request = new Request(url, requestInit);

--- a/tests/unit/repositories/api-tokens.test.ts
+++ b/tests/unit/repositories/api-tokens.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../src/lib/server/db/index", () => ({
+	db: {
+		insert: vi.fn(),
+		select: vi.fn(),
+		delete: vi.fn(),
+		update: vi.fn(),
+	},
+}));
+
+vi.mock("../../../src/lib/server/db/schema", () => ({
+	apiTokens: {
+		id: "id",
+		userId: "user_id",
+		tokenHash: "token_hash",
+		label: "label",
+		expiresAt: "expires_at",
+		lastUsedAt: "last_used_at",
+		createdAt: "created_at",
+	},
+}));
+
+vi.mock("uuid", () => ({ v4: vi.fn(() => "mock-uuid-1234") }));
+
+vi.mock("../../../src/lib/server/auth/api-token", () => ({
+	generateToken: vi.fn(() => ({ token: "tb_rawtoken123", hash: "hashvalue123" })),
+	TOKEN_TTL_MS: 90 * 24 * 60 * 60 * 1000,
+}));
+
+import { db } from "../../../src/lib/server/db/index";
+import {
+	cleanupExpiredTokens,
+	createApiToken,
+	listApiTokens,
+	revokeApiToken,
+} from "../../../src/lib/server/repositories/api-tokens";
+
+describe("createApiToken", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("inserts a token and returns the raw token + info", async () => {
+		const mockValues = vi.fn().mockResolvedValue(undefined);
+		const mockInsert = { values: mockValues };
+		vi.mocked(db.insert).mockReturnValue(mockInsert as any);
+
+		const result = await createApiToken("user-1", "My AI agent");
+
+		expect(db.insert).toHaveBeenCalled();
+		expect(mockValues).toHaveBeenCalledWith(
+			expect.objectContaining({
+				id: "mock-uuid-1234",
+				userId: "user-1",
+				label: "My AI agent",
+				tokenHash: "hashvalue123",
+			}),
+		);
+		expect(result.rawToken).toBe("tb_rawtoken123");
+		expect(result.tokenInfo.label).toBe("My AI agent");
+		expect(result.tokenInfo.id).toBe("mock-uuid-1234");
+		expect(result.tokenInfo.expiresAt).toBeGreaterThan(Date.now());
+	});
+});
+
+describe("listApiTokens", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("queries tokens for the given user and excludes expired ones", async () => {
+		const mockTokens = [
+			{ id: "tok-1", label: "Agent", expiresAt: Date.now() + 1000000, lastUsedAt: null, createdAt: Date.now() },
+		];
+		const mockWhere = vi.fn().mockReturnValue({ orderBy: vi.fn().mockResolvedValue(mockTokens) });
+		const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+		vi.mocked(db.select).mockReturnValue({ from: mockFrom } as any);
+
+		const result = await listApiTokens("user-1");
+
+		expect(db.select).toHaveBeenCalled();
+		expect(result).toEqual(mockTokens);
+	});
+});
+
+describe("revokeApiToken", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("returns true when a token is deleted", async () => {
+		const mockWhere = vi.fn().mockResolvedValue({ rowsAffected: 1 });
+		const mockDelete = { where: mockWhere };
+		vi.mocked(db.delete).mockReturnValue(mockDelete as any);
+
+		const result = await revokeApiToken("tok-1", "user-1");
+
+		expect(result).toBe(true);
+		expect(mockWhere).toHaveBeenCalled();
+	});
+
+	it("returns false when no token is deleted (wrong user or id)", async () => {
+		const mockWhere = vi.fn().mockResolvedValue({ rowsAffected: 0 });
+		const mockDelete = { where: mockWhere };
+		vi.mocked(db.delete).mockReturnValue(mockDelete as any);
+
+		const result = await revokeApiToken("nonexistent", "user-1");
+
+		expect(result).toBe(false);
+	});
+});
+
+describe("cleanupExpiredTokens", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("calls delete with a timestamp filter", async () => {
+		const mockWhere = vi.fn().mockResolvedValue(undefined);
+		vi.mocked(db.delete).mockReturnValue({ where: mockWhere } as any);
+
+		await cleanupExpiredTokens();
+
+		expect(db.delete).toHaveBeenCalled();
+		expect(mockWhere).toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
Introduces a versioned REST API (/api/v1) for programmatic and AI client access, backed by 90-day bearer tokens issued from the user profile page.

Key changes:
- Migration 0016: adds api_tokens table (handwritten to avoid Drizzle composite- index generation bug; only single-column indexes used)
- Migration 0015 (postgres): made idempotent with DO $$ guard so it's safe on databases that already have the continuation_enabled columns; registers missing postgres journal entry
- Schema: apiTokens table + relations, scorecardDatasources.sourceType extended to include 'ai'
- Auth: generateToken/hashToken/validateApiToken (SHA-256, no bcrypt overhead); requireApiV1Auth() accepts Bearer token or session cookie
- Repository: createApiToken, listApiTokens, revokeApiToken, cleanupExpiredTokens
- Routes: GET/POST /tokens, DELETE /tokens/:id, GET /series, GET+POST /series/:id/boards (batch-create with columns/scenes/seed-cards), GET /series/:id/agreements, GET /series/:id/health-summary, GET /boards/:id, GET /boards/:id/cards, GET /boards/:id/agreements, GET /boards/:id/scorecard-results, POST /datasources/:id/inject (AI push), GET /openapi.json
- Profile page: ApiTokenManager component (create/revoke/copy, expiry warning)
- 84 new unit tests; all 393 tests pass
- docs/api-v1-spec.md: canonical spec that tests verify against